### PR TITLE
Support pre-set ratio

### DIFF
--- a/Mantis/Source/CropViewController/CropToolbar.swift
+++ b/Mantis/Source/CropViewController/CropToolbar.swift
@@ -104,12 +104,15 @@ class CropToolbar: UIView {
         }
     }
     
-    func createToolbarUI(mode: CropToolbarMode = .normal) {
+    func createToolbarUI(mode: CropToolbarMode = .normal, includeSetRatioButton: Bool = true) {
         createButtonContainer()
         setButtonContainerLayout()
 
         createRotationButton()
-        createSetRatioButton()
+        
+        if includeSetRatioButton {
+            createSetRatioButton()
+        }
 
         if mode == .normal {
             createResetButton(with: ToolBarButtonImageBuilder.resetImage())

--- a/Mantis/Source/CropViewController/CropViewController.swift
+++ b/Mantis/Source/CropViewController/CropViewController.swift
@@ -88,7 +88,14 @@ public class CropViewController: UIViewController {
         cropToolbar.selectedCrop = {[weak self] in self?.handleCrop() }
         
         if mode == .normal {
-            cropToolbar.createToolbarUI()
+            if config.ratioOptions == .original || config.ratioOptions == .square {
+                // If pre-set ratioOptions to only contain a single ratio, then don't add ratio button
+                cropToolbar.createToolbarUI(includeSetRatioButton: false)
+                // Calling this will apply the current ratio
+                handleSetRatio()
+            } else {
+                cropToolbar.createToolbarUI(includeSetRatioButton: true)
+            }
         } else {
             cropToolbar.createToolbarUI(mode: .simple)
         }

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ public protocol CropViewControllerDelegate: class {
 ```swift
 let cropViewController = Mantis.cropViewController(image: <Your Image>)
 ```
+  You could also set a fixed ratio e.g `original` or `square`, and then the ratio selection button won't show up.
+
+```swift
+cropViewController.config.ratioOptions = .square
+``` 
 
   * customizable mode
   
@@ -85,12 +90,12 @@ let cropViewController = Mantis.cropCustomizableViewController(image: <Your Imag
 * Add your own ratio
 ```swift
             // Add a custom ratio 1:2 for portrait orientation
-            let config = MantisConfig()
+            let config = Mantis.Config()
             config.addCustomRatio(byVerticalWidth: 1, andVerticalHeight: 2)            
             <Your ViewController> = Mantis.cropViewController(image: <Your Image>, config: config)
             
             // Set the ratioOptions of the config if you don't want to keep all default ratios
-            let config = MantisConfig() 
+            let config = Mantis.Config() 
             //config.ratioOptions = [.original, .square, .custom]
             config.ratioOptions = [.custom]
             config.addCustomRatio(byVerticalWidth: 1, andVerticalHeight: 2)            


### PR DESCRIPTION
This allows app to preset the ratio to e.g. `square` and don't allow changing ratio for avatars etc.

Updated readme with it, and fixed an outdated part.