### PR TITLE
Add config setting to hide toolbar and make button handlers public

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -80,6 +80,7 @@ public class CropViewController: UIViewController {
     }
         
     fileprivate func createCropToolbar() {
+        cropToolbar.isHidden = !config.showToolbar
         cropToolbar.backgroundColor = .black
         
         cropToolbar.optionButtonFontSize = config.optionButtonFontSize
@@ -218,7 +219,7 @@ public class CropViewController: UIViewController {
         }
     }
     
-    private func handleCancel() {
+    public func handleCancel() {
         delegate?.cropViewControllerWillDismiss(self)
         dismiss(animated: true) { [weak self] in
             guard let self = self else { return }
@@ -231,7 +232,7 @@ public class CropViewController: UIViewController {
         cropToolbar.setRatioButton?.tintColor = .white
     }
     
-    @objc private func handleSetRatio() {
+    @objc public func handleSetRatio() {
         if cropView.aspectRatioLockEnabled {
             resetRatioButton()
             return
@@ -255,16 +256,16 @@ public class CropViewController: UIViewController {
         ratioPresenter?.present(by: self, in: cropToolbar.setRatioButton!)
     }
     
-    private func handleReset() {
+    public func handleReset() {
         resetRatioButton()
         cropView.reset()
     }
     
-    private func handleRotate() {
+    public func handleRotate() {
         cropView.counterclockwiseRotate90()
     }
     
-    private func handleCrop() {
+    public func handleCrop() {
         let cropResult = cropView.crop()
         guard let image = cropResult.croppedImage else {
             delegate?.cropViewControllerDidFailToCrop(self, original: cropView.image)

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -82,6 +82,7 @@ public struct Config {
     public var ratioOptions: RatioOptions = .all
     public var presetFixedRatioType: PresetFixedRatioType = .canUseMultiplePresetFixedRatio
     public var showRotationDial = true
+    public var showToolbar = true
     public var optionButtonFontSize: CGFloat = 14
     public var optionButtonFontSizeForPad: CGFloat = 20
     


### PR DESCRIPTION
In order to be able to implement a custom toolbar, I added the config option to hide the default toolbar and made the toolbar button's handlers public.