### PR TITLE
Improve function namings of CropToolbarDelegate and CropToolbarProtocol

### DIFF
--- a/Example/CustomizedCropToolbar.swift
+++ b/Example/CustomizedCropToolbar.swift
@@ -59,15 +59,15 @@ class CustomizedCropToolbar: UIView, CropToolbarProtocol {
     }
             
     @objc private func crop() {
-        cropToolbarDelegate?.didSelectedCrop()
+        cropToolbarDelegate?.didSelecteCrop()
     }
     
     @objc private func cancel() {
-        cropToolbarDelegate?.didSelectedCancel()
+        cropToolbarDelegate?.didSelecteCancel()
     }
     
     @objc private func showRatioList() {
-        cropToolbarDelegate?.didSelectedSetRatio()
+        cropToolbarDelegate?.didSelecteSetRatio()
     }
     
     private func createOptionButton(withTitle title: String?, andAction action: Selector) -> UIButton {

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -6,8 +6,8 @@ target 'MantisExample' do
   use_frameworks!
 
   # Pods for MantisExample
-#  pod 'Mantis', :path => '../'
-  pod 'Mantis', '~> 1.1.0'
+  pod 'Mantis', :path => '../'
+#  pod 'Mantis', '~> 1.1.0'
 
   target 'MantisExampleTests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,15 +2,15 @@ PODS:
   - Mantis (1.1.0)
 
 DEPENDENCIES:
-  - Mantis (~> 1.1.0)
+  - Mantis (from `../`)
 
-SPEC REPOS:
-  trunk:
-    - Mantis
+EXTERNAL SOURCES:
+  Mantis:
+    :path: "../"
 
 SPEC CHECKSUMS:
   Mantis: 50944b1d82a8ead22dd8f8765c87337fab2f642d
 
-PODFILE CHECKSUM: 987aa60605937fbed4941c0458a2280fda34c616
+PODFILE CHECKSUM: 18a0c8f4e5ce0574b01b276d9d5b862a719dc5ce
 
 COCOAPODS: 1.9.1

--- a/Mantis.podspec
+++ b/Mantis.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Mantis"
-  s.version      = "1.1.0"
+  s.version      = "1.1.1"
   s.summary      = "A swift photo cropping tool which mimics Photo.app"
 
   s.description  = <<-DESC

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -644,7 +644,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";
@@ -674,7 +674,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				MACOSX_DEPLOYMENT_TARGET = 10.15;
-				MARKETING_VERSION = 1.1.0;
+				MARKETING_VERSION = 1.1.1;
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
 				OTHER_SWIFT_FLAGS = "$(inherited)";

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Thanks [Leo Dabus](https://stackoverflow.com/users/2303865/leo-dabus) for helpin
 ### CocoaPods
 
 ```ruby
-pod 'Mantis', '~> 1.1.0'
+pod 'Mantis', '~> 1.1.1'
 ```
 
 ### Carthage

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -146,6 +146,9 @@ class CropView: UIView {
     
     private func imageStatusChanged() -> Bool {
         if viewModel.getTotalRadians() != 0 { return true }
+        
+        if (forceFixedRatio) { return scrollView.zoomScale != 1 }
+        
         if !isTheSamePoint(p1: getImageLeftTopAnchorPoint(), p2: .zero) {
             return true
         }

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -610,6 +610,7 @@ extension CropView {
         
         viewModel.reset(forceFixedRatio: forceFixedRatio)
         resetUIFrame()
+        delegate?.cropViewDidBecomeUnResettable(self)
     }
     
     func prepareForDeviceRotation() {

--- a/Sources/Mantis/CropViewController/CropToolbar.swift
+++ b/Sources/Mantis/CropViewController/CropToolbar.swift
@@ -131,6 +131,8 @@ public class CropToolbar: UIView, CropToolbarProtocol {
             createResetButton()
             addButtonsToContainer(buttons: [anticlockRotateButton, resetButton, fixedRatioSettingButton])
         }
+        
+        resetButton?.isHidden = true
     }
     
     public func getRatioListPresentSourceView() -> UIView? {
@@ -147,11 +149,11 @@ public class CropToolbar: UIView, CropToolbarProtocol {
         }
     }
     
-    public func adjustUIWhenFixedRatioSetted() {
+    public func handleFixedRatioSetted() {
         fixedRatioSettingButton?.tintColor = nil
     }
     
-    public func adjustUIWhenFixedRatioUnSetted() {
+    public func handleFixedRatioUnSetted() {
         fixedRatioSettingButton?.tintColor = .white
     }
     
@@ -168,22 +170,22 @@ public class CropToolbar: UIView, CropToolbarProtocol {
     }
     
     @objc private func cancel() {
-        cropToolbarDelegate?.didSelectedCancel()
+        cropToolbarDelegate?.didSelecteCancel()
     }
     
     @objc private func setRatio() {
-        cropToolbarDelegate?.didSelectedSetRatio()
+        cropToolbarDelegate?.didSelecteSetRatio()
     }
     
     @objc private func reset(_ sender: Any) {
-        cropToolbarDelegate?.didSelectedReset()
+        cropToolbarDelegate?.didSelecteReset()
     }
     
     @objc private func rotate(_ sender: Any) {
-        cropToolbarDelegate?.didSelectedRotate()
+        cropToolbarDelegate?.didSelecteRotate()
     }
     
     @objc private func crop(_ sender: Any) {
-        cropToolbarDelegate?.didSelectedCrop()
+        cropToolbarDelegate?.didSelecteCrop()
     }
 }

--- a/Sources/Mantis/CropViewController/CropToolbarProtocol.swift
+++ b/Sources/Mantis/CropViewController/CropToolbarProtocol.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 public protocol CropToolbarDelegate {
-    func didSelectedCancel();
-    func didSelectedCrop();
-    func didSelectedRotate();
-    func didSelectedReset();
-    func didSelectedSetRatio();
+    func didSelecteCancel();
+    func didSelecteCrop();
+    func didSelecteRotate();
+    func didSelecteReset();
+    func didSelecteSetRatio();
 }
 
 public protocol CropToolbarProtocol: UIView {    
@@ -32,8 +32,8 @@ public protocol CropToolbarProtocol: UIView {
     func adjustLayoutConstraintsWhenOrientationChange()
     func adjustUIWhenOrientationChange()
     
-    func adjustUIWhenFixedRatioSetted()
-    func adjustUIWhenFixedRatioUnSetted()
+    func handleFixedRatioSetted()
+    func handleFixedRatioUnSetted()
     
     func handleCropViewDidBecomeResettable()
     func handleCropViewDidBecomeUnResettable()
@@ -68,11 +68,11 @@ public extension CropToolbarProtocol {
         
     }
     
-    func adjustUIWhenFixedRatioSetted() {
+    func handleFixedRatioSetted() {
 
     }
     
-    func adjustUIWhenFixedRatioUnSetted() {
+    func handleFixedRatioUnSetted() {
 
     }
     

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -177,7 +177,7 @@ public class CropViewController: UIViewController {
     }
     
     func setFixedRatio(_ ratio: Double) {
-        cropToolbar.adjustUIWhenFixedRatioSetted()
+        cropToolbar.handleFixedRatioSetted()
         cropView.aspectRatioLockEnabled = true
         cropView.viewModel.aspectRatio = CGFloat(ratio)
         
@@ -218,7 +218,7 @@ public class CropViewController: UIViewController {
     
     private func resetRatioButton() {
         cropView.aspectRatioLockEnabled = false
-        cropToolbar.adjustUIWhenFixedRatioUnSetted()
+        cropToolbar.handleFixedRatioUnSetted()
     }
     
     @objc private func handleSetRatio() {
@@ -328,23 +328,23 @@ extension CropViewController: CropViewDelegate {
 }
 
 extension CropViewController: CropToolbarDelegate {
-    public func didSelectedCancel() {
+    public func didSelecteCancel() {
         handleCancel()
     }
     
-    public func didSelectedCrop() {
+    public func didSelecteCrop() {
         handleCrop()
     }
     
-    public func didSelectedRotate() {
+    public func didSelecteRotate() {
         handleRotate()
     }
     
-    public func didSelectedReset() {
+    public func didSelecteReset() {
         handleReset()
     }
     
-    public func didSelectedSetRatio() {
+    public func didSelecteSetRatio() {
         handleSetRatio()
     }
 }


### PR DESCRIPTION
Add delegate?.cropViewDidBecomeUnResettable(self) to func reset() in CropView.swift
Hide reset button in the beginning.