### PR TITLE
Resize begin and end events

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -172,8 +172,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ACL-Rq-bqb">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NDR-Th-Zyy" userLabel="Resolution label">
+                                        <rect key="frame" x="170" y="16.5" width="35.5" height="17"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="1Ba-d3-nV2"/>
+                                    <constraint firstItem="NDR-Th-Zyy" firstAttribute="centerX" secondItem="ACL-Rq-bqb" secondAttribute="centerX" id="GS9-M7-g4d"/>
+                                    <constraint firstItem="NDR-Th-Zyy" firstAttribute="centerY" secondItem="ACL-Rq-bqb" secondAttribute="centerY" id="f80-wE-HMG"/>
+                                </constraints>
+                            </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="lwW-G6-m16">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                                <rect key="frame" x="0.0" y="50" width="375" height="568"/>
                                 <connections>
                                     <segue destination="xJq-Ev-XcJ" kind="embed" id="WEI-AV-e4o"/>
                                 </connections>
@@ -182,9 +199,13 @@
                         <viewLayoutGuide key="safeArea" id="cY0-Cd-i0E"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="lwW-G6-m16" firstAttribute="top" secondItem="cY0-Cd-i0E" secondAttribute="top" id="F4s-gV-IK0"/>
+                            <constraint firstItem="ACL-Rq-bqb" firstAttribute="leading" secondItem="cY0-Cd-i0E" secondAttribute="leading" id="8WS-ZD-j1X"/>
+                            <constraint firstItem="lwW-G6-m16" firstAttribute="bottom" secondItem="cY0-Cd-i0E" secondAttribute="bottom" id="N8R-1Y-ZWi"/>
+                            <constraint firstItem="lwW-G6-m16" firstAttribute="top" secondItem="ACL-Rq-bqb" secondAttribute="bottom" id="RHu-2R-hrm"/>
                             <constraint firstItem="lwW-G6-m16" firstAttribute="leading" secondItem="cY0-Cd-i0E" secondAttribute="leading" id="Rbf-LE-Lbb"/>
                             <constraint firstItem="cY0-Cd-i0E" firstAttribute="trailing" secondItem="lwW-G6-m16" secondAttribute="trailing" id="XLc-Sl-Rfe"/>
+                            <constraint firstItem="ACL-Rq-bqb" firstAttribute="top" secondItem="cY0-Cd-i0E" secondAttribute="top" id="mTM-oP-oDm"/>
+                            <constraint firstItem="cY0-Cd-i0E" firstAttribute="trailing" secondItem="ACL-Rq-bqb" secondAttribute="trailing" id="qqV-Nd-YWn"/>
                             <constraint firstItem="cY0-Cd-i0E" firstAttribute="bottom" secondItem="lwW-G6-m16" secondAttribute="bottom" id="yuD-jJ-uPY"/>
                         </constraints>
                     </view>
@@ -218,6 +239,7 @@
                     <connections>
                         <outlet property="cancelButton" destination="5p4-Ob-R9b" id="kQq-ir-MSf"/>
                         <outlet property="doneButton" destination="kZP-3N-vXv" id="RPY-W3-vWu"/>
+                        <outlet property="resolutionLabel" destination="NDR-Th-Zyy" id="rUQ-h6-q2i"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="xP6-ML-BEH" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -253,7 +275,7 @@
             <objects>
                 <viewController id="xJq-Ev-XcJ" customClass="CropViewController" customModule="Mantis" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="nLp-HP-0xC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="0JZ-7h-zil"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -263,9 +285,26 @@
             </objects>
             <point key="canvasLocation" x="1042" y="819"/>
         </scene>
+        <!--View Controller-->
+        <scene sceneID="pAG-Yc-5gI">
+            <objects>
+                <viewController id="1ww-pC-jt2" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rV8-rb-bEL">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="y0z-sv-kI9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2014" y="-449"/>
+        </scene>
     </scenes>
     <resources>
         <image name="sunflower" width="3648" height="5472"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -285,26 +285,9 @@
             </objects>
             <point key="canvasLocation" x="1042" y="819"/>
         </scene>
-        <!--View Controller-->
-        <scene sceneID="pAG-Yc-5gI">
-            <objects>
-                <viewController id="1ww-pC-jt2" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="rV8-rb-bEL">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="y0z-sv-kI9" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="2014" y="-449"/>
-        </scene>
     </scenes>
     <resources>
         <image name="sunflower" width="3648" height="5472"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemGray6Color">
             <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/Example/EmbeddedCropViewController.swift
+++ b/Example/EmbeddedCropViewController.swift
@@ -18,12 +18,14 @@ class EmbeddedCropViewController: UIViewController {
     
     @IBOutlet weak var cancelButton: UIBarButtonItem!
     @IBOutlet weak var doneButton: UIBarButtonItem!
+    @IBOutlet weak var resolutionLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         cancelButton.title = "Cancel"
         doneButton.title = "Done"
+        resolutionLabel.text = "\(getResolution(image: image) ?? "unknown")"
     }
     
     @IBAction func cancel(_ sender: Any) {
@@ -48,6 +50,13 @@ class EmbeddedCropViewController: UIViewController {
             cropViewController = vc
         }
     }
+    
+    private func getResolution(image: UIImage?) -> String? {
+        if let size = image?.size {
+            return "\(size.width) x \(size.height)px"
+        }
+        return nil
+    }
 }
 
 extension EmbeddedCropViewController: CropViewControllerDelegate {
@@ -59,4 +68,13 @@ extension EmbeddedCropViewController: CropViewControllerDelegate {
     func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage) {
         self.dismiss(animated: true)
     }
+    
+    func cropViewControllerDidBeginResize(_ cropViewController: CropViewController) {
+        self.resolutionLabel.text = "..."
+    }
+    
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation) {
+        self.resolutionLabel.text = getResolution(image: cropped)
+    }
+
 }

--- a/Example/EmbeddedCropViewController.swift
+++ b/Example/EmbeddedCropViewController.swift
@@ -73,8 +73,9 @@ extension EmbeddedCropViewController: CropViewControllerDelegate {
         self.resolutionLabel.text = "..."
     }
     
-    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation) {
-        self.resolutionLabel.text = getResolution(image: cropped)
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo) {
+        let croppedImage = Mantis.getCroppedImage(byCropInfo: cropInfo, andImage: original)
+        self.resolutionLabel.text = getResolution(image: croppedImage)
     }
 
 }

--- a/Example/EmbeddedCropViewController.swift
+++ b/Example/EmbeddedCropViewController.swift
@@ -53,7 +53,7 @@ class EmbeddedCropViewController: UIViewController {
     
     private func getResolution(image: UIImage?) -> String? {
         if let size = image?.size {
-            return "\(size.width) x \(size.height)px"
+            return "\(Int(size.width)) x \(Int(size.height)) pixels"
         }
         return nil
     }

--- a/Sources/Mantis/CropView/CropView+Touches.swift
+++ b/Sources/Mantis/CropView/CropView+Touches.swift
@@ -36,14 +36,14 @@ extension CropView {
             return
         }
         
+        // A resize event has begun by grabbing the crop UI, so notify delegate
+        delegate?.cropViewDidBeginResize(self)
+        
         if touch.view is RotationDial {
             viewModel.setTouchRotationBoardStatus()
             return
         }
         
-        // A resize event has begun by grabbing the crop UI, so notify delegate
-        delegate?.cropViewDidBeginResize(self)
-
         let point = touch.location(in: self)
         viewModel.prepareForCrop(byTouchPoint: point)
     }

--- a/Sources/Mantis/CropView/CropView+Touches.swift
+++ b/Sources/Mantis/CropView/CropView+Touches.swift
@@ -41,6 +41,9 @@ extension CropView {
             return
         }
         
+        // A resize event has begun by grabbing the crop UI, so notify delegate
+        delegate?.cropViewDidBeginResize(self)
+
         let point = touch.location(in: self)
         viewModel.prepareForCrop(byTouchPoint: point)
     }
@@ -67,10 +70,12 @@ extension CropView {
             gridOverlayView.handleEdgeUntouched()
             let contentRect = getContentBounds()
             adjustUIForNewCrop(contentRect: contentRect) {[weak self] in
+                self?.delegate?.cropViewDidEndResize(self!)
                 self?.viewModel.setBetweenOperationStatus()
                 self?.scrollView.updateMinZoomScale()
             }
         } else {
+            delegate?.cropViewDidEndResize(self)
             viewModel.setBetweenOperationStatus()
         }
     }

--- a/Sources/Mantis/CropView/CropView+UIScrollViewDelegate.swift
+++ b/Sources/Mantis/CropView/CropView+UIScrollViewDelegate.swift
@@ -18,6 +18,8 @@ extension CropView: UIScrollViewDelegate {
     }
     
     func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+        // A resize event has begun via gesture on the photo (scrollview), so notify delegate
+        self.delegate?.cropViewDidBeginResize(self)
         viewModel.setTouchImageStatus()
     }
     
@@ -26,7 +28,7 @@ extension CropView: UIScrollViewDelegate {
     }
     
     func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
-
+        self.delegate?.cropViewDidEndResize(self)
         makeSureImageContainsCropOverlay()
         
         manualZoomed = true

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -27,6 +27,8 @@ import UIKit
 protocol CropViewDelegate: class {
     func cropViewDidBecomeResettable(_ cropView: CropView)
     func cropViewDidBecomeUnResettable(_ cropView: CropView)
+    func cropViewDidBeginResize(_ cropView: CropView)
+    func cropViewDidEndResize(_ cropView: CropView)
 }
 
 let cropViewMinimumBoxSize: CGFloat = 42

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -570,9 +570,7 @@ extension CropView {
         let zeroPoint = gridOverlayView.center
         
         let translation =  CGPoint(x: (point.x - zeroPoint.x), y: (point.y - zeroPoint.y))
-        
-        print(gridOverlayView.frame)
-        
+                
         return CropInfo(
             translation: translation,
             rotation: getTotalRadians(),

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -534,27 +534,12 @@ extension CropView {
 // MARK: - internal API
 extension CropView {
     func crop(_ image: UIImage) -> (croppedImage: UIImage?, transformation: Transformation) {
-        let rect = imageContainer.convert(imageContainer.bounds,
-                                          to: self)
-        let point = rect.center
-        let zeroPoint = gridOverlayView.center
-        
-        let translation =  CGPoint(x: (point.x - zeroPoint.x), y: (point.y - zeroPoint.y))
-        let totalRadians = forceFixedRatio ? viewModel.radians : viewModel.getTotalRadians()
-        
-        print(gridOverlayView.frame)
-        
-        let info = CropInfo(
-            translation: translation,
-            rotation: totalRadians,
-            scale: scrollView.zoomScale,
-            cropSize: gridOverlayView.frame.size,
-            imageViewSize: imageContainer.bounds.size
-        )
+
+        let info = getCropInfo()
         
         let transformation = Transformation(
             offset: scrollView.contentOffset,
-            rotation: totalRadians,
+            rotation: getTotalRadians(),
             scale: scrollView.zoomScale,
             manualZoomed: manualZoomed,
             intialMaskFrame: viewModel.cropOrignFrame,
@@ -575,6 +560,31 @@ extension CropView {
             let radius = min(croppedImage.size.width, croppedImage.size.height) * radiusToShortSide
             return (croppedImage.roundRect(radius), transformation)
         }
+    }
+    
+    func getCropInfo() -> CropInfo {
+        
+        let rect = imageContainer.convert(imageContainer.bounds,
+                                          to: self)
+        let point = rect.center
+        let zeroPoint = gridOverlayView.center
+        
+        let translation =  CGPoint(x: (point.x - zeroPoint.x), y: (point.y - zeroPoint.y))
+        
+        print(gridOverlayView.frame)
+        
+        return CropInfo(
+            translation: translation,
+            rotation: getTotalRadians(),
+            scale: scrollView.zoomScale,
+            cropSize: gridOverlayView.frame.size,
+            imageViewSize: imageContainer.bounds.size
+        )
+        
+    }
+    
+    func getTotalRadians() -> CGFloat {
+        return forceFixedRatio ? viewModel.radians : viewModel.getTotalRadians()
     }
     
     func crop() -> (croppedImage: UIImage?, transformation: Transformation) {

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -29,15 +29,18 @@ public protocol CropViewControllerDelegate: class {
                                    cropped: UIImage, transformation: Transformation)
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage)
     func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage)
-    func cropViewControllerDidBecomeResettable(_ cropViewController: CropViewController)
     
+    func cropViewControllerDidBeginResize(_ cropViewController: CropViewController)
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation)
+
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController)
 }
 
 public extension CropViewControllerDelegate where Self: UIViewController {
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {}
-    func cropViewControllerDidBecomeResettable(_ cropViewController: CropViewController) {}
+    func cropViewControllerDidBeginResize(_ cropViewController: CropViewController) {}
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation) {}
 
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController) {}
@@ -431,13 +434,24 @@ extension CropViewController {
 }
 
 extension CropViewController: CropViewDelegate {
+    
     func cropViewDidBecomeResettable(_ cropView: CropView) {
         cropToolbar.handleCropViewDidBecomeResettable()
-        delegate?.cropViewControllerDidBecomeResettable(self)
     }
     
     func cropViewDidBecomeUnResettable(_ cropView: CropView) {
         cropToolbar.handleCropViewDidBecomeUnResettable()
+    }
+    
+    func cropViewDidBeginResize(_ cropView: CropView) {
+        delegate?.cropViewControllerDidBeginResize(self)
+    }
+    
+    func cropViewDidEndResize(_ cropView: CropView) {
+        let (croppedImage, transformation) = cropView.crop()
+        if let croppedImage = croppedImage {
+            delegate?.cropViewControllerDidEndResize(self, cropped: croppedImage, transformation: transformation)
+        }
     }
 }
 

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -29,6 +29,7 @@ public protocol CropViewControllerDelegate: class {
                                    cropped: UIImage, transformation: Transformation)
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage)
     func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage)
+    func cropViewControllerDidBecomeResettable(_ cropViewController: CropViewController)
     
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController)
@@ -36,7 +37,8 @@ public protocol CropViewControllerDelegate: class {
 
 public extension CropViewControllerDelegate where Self: UIViewController {
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {}
-    
+    func cropViewControllerDidBecomeResettable(_ cropViewController: CropViewController) {}
+
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController) {}
 }
@@ -431,6 +433,7 @@ extension CropViewController {
 extension CropViewController: CropViewDelegate {
     func cropViewDidBecomeResettable(_ cropView: CropView) {
         cropToolbar.handleCropViewDidBecomeResettable()
+        delegate?.cropViewControllerDidBecomeResettable(self)
     }
     
     func cropViewDidBecomeUnResettable(_ cropView: CropView) {

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -31,7 +31,7 @@ public protocol CropViewControllerDelegate: class {
     func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage)
     
     func cropViewControllerDidBeginResize(_ cropViewController: CropViewController)
-    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation)
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo)
 
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController)
@@ -40,7 +40,7 @@ public protocol CropViewControllerDelegate: class {
 public extension CropViewControllerDelegate where Self: UIViewController {
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {}
     func cropViewControllerDidBeginResize(_ cropViewController: CropViewController) {}
-    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation) {}
+    func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo) {}
 
     @available(*, deprecated, message: "Mantis doesn't dismiss CropViewController anymore since 1.2.0. You need to dismiss it by yourself.")
     func cropViewControllerWillDismiss(_ cropViewController: CropViewController) {}
@@ -448,10 +448,7 @@ extension CropViewController: CropViewDelegate {
     }
     
     func cropViewDidEndResize(_ cropView: CropView) {
-        let (croppedImage, transformation) = cropView.crop()
-        if let croppedImage = croppedImage {
-            delegate?.cropViewControllerDidEndResize(self, cropped: croppedImage, transformation: transformation)
-        }
+        delegate?.cropViewControllerDidEndResize(self, original: cropView.image, cropInfo: cropView.getCropInfo())
     }
 }
 


### PR DESCRIPTION
Fixes #65 

Adds two new delegate function to the CropViewController, which can be used to respond to the user starting and finishing a crop gesture (via pinch-to-zoom or dragging crop rectangle):

`func cropViewControllerDidBeginResize(_ cropViewController: CropViewController)`
`func cropViewControllerDidEndResize(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation)`

Provides an example in the EmbeddedCropViewController for how to use these hooks to display the current resolution of the cropped area of a photo.