### PR TITLE
Additional background crop effects

### DIFF
--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -127,15 +127,40 @@
                                             </button>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9WR-aF-zl2" userLabel="Hide Rotation Dial">
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="bu4-cG-VOh">
                                         <rect key="frame" x="0.0" y="227" width="306" height="34"/>
-                                        <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                        <state key="normal" title="No Visual Background Effect"/>
-                                        <connections>
-                                            <action selector="noBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Chc-Ek-cMW"/>
-                                        </connections>
-                                    </button>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9WR-aF-zl2">
+                                                <rect key="frame" x="0.0" y="0.0" width="98.5" height="34"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                <state key="normal" title="Dark Background"/>
+                                                <connections>
+                                                    <action selector="darkBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="edW-tG-CJq"/>
+                                                    <action selector="noBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Chc-Ek-cMW"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FmB-6O-5mY">
+                                                <rect key="frame" x="103.5" y="0.0" width="99" height="34"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                <state key="normal" title="Light Background"/>
+                                                <connections>
+                                                    <action selector="lightBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="K1m-Uc-kdy"/>
+                                                    <action selector="noBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tYd-3z-IQT"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iaH-5e-UFH">
+                                                <rect key="frame" x="207.5" y="0.0" width="98.5" height="34"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                <state key="normal" title="No Background"/>
+                                                <connections>
+                                                    <action selector="noBackgroundEffect:" destination="BYZ-38-t0r" eventType="touchUpInside" id="7oq-dx-dxn"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="305" id="Rnv-Qx-Cds"/>

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -168,14 +168,26 @@ class ViewController: UIViewController, CropViewControllerDelegate {
         cropViewController.delegate = self
         present(cropViewController, animated: true)
     }
-
+    
+    @IBAction func darkBackgroundEffect(_ sender: Any) {
+        presentWith(backgroundEffect: .dark)
+    }
+    
+    @IBAction func lightBackgroundEffect(_ sender: Any) {
+        presentWith(backgroundEffect: .light)
+    }
+    
     @IBAction func noBackgroundEffect(_ sender: Any) {
+        presentWith(backgroundEffect: .none)
+    }
+    
+    private func presentWith(backgroundEffect effect: CropVisualEffectType) {
         guard let image = image else {
             return
         }
         
         var config = Mantis.Config()
-        config.cropVisualEffectType = .none
+        config.cropVisualEffectType = effect
         let cropViewController = Mantis.cropViewController(image: image,
                                                            config: config)
         cropViewController.modalPresentationStyle = .fullScreen

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -77,6 +77,8 @@ public enum PresetFixedRatioType {
 
 public enum CropVisualEffectType {
     case blurDark
+    case dark
+    case light
     case none
 }
 

--- a/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
+++ b/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
@@ -15,12 +15,12 @@ class CropVisualEffectView: UIVisualEffectView, CropMaskProtocol {
     
     convenience init(cropShapeType: CropShapeType = .rect, effectType: CropVisualEffectType = .blurDark) {
         
-        let translucencyEffect = CropVisualEffectView.getEffect(byType: effectType)
+        let (translucencyEffect, backgroundColor) = CropVisualEffectView.getEffect(byType: effectType)
         
         self.init(effect: translucencyEffect)
         self.cropShapeType = cropShapeType
         self.translucencyEffect = translucencyEffect
-        self.backgroundColor = effectType == .none ? .black : .clear
+        self.backgroundColor = backgroundColor
         
         initialize()
     }
@@ -35,10 +35,13 @@ class CropVisualEffectView: UIVisualEffectView, CropMaskProtocol {
         self.mask = maskView
     }
     
-    static func getEffect(byType type: CropVisualEffectType) -> UIVisualEffect? {
+    static func getEffect(byType type: CropVisualEffectType) -> (UIVisualEffect?, UIColor) {
         switch type {
-        case .blurDark: return UIBlurEffect(style: .dark)
-        case .none: return nil
+            case .blurDark: return (UIBlurEffect(style: .dark), .clear)
+            case .dark: return (nil, UIColor.black.withAlphaComponent(0.75))
+            case .light: return (nil, UIColor.black.withAlphaComponent(0.35))
+            case .none: return (nil, .black)
         }
     }
+    
 }


### PR DESCRIPTION
This PR adds two new background effects which are applied over the top of any cropped part of an image:

* Dark: Masks the cropped area with an opacity that is darker than the mask that appears when you perform cropping actions, making the cropped area appear to darken after an action.
![darken](https://user-images.githubusercontent.com/5530491/98143485-11239c80-1ec1-11eb-81a3-9102d2e5dcb6.gif)

* Light: Masks the cropped area with an opacity that is lighter than the mask that appears when you perform cropping actions (although still darker than the image itself), making the cropped area appear to lighten after an action.
![lighten](https://user-images.githubusercontent.com/5530491/98143493-141e8d00-1ec1-11eb-8b4e-843938509952.gif)
