### PR TITLE
Configurable animation when loading an embedded controller

### DIFF
--- a/Example/EmbeddedCropViewController.swift
+++ b/Example/EmbeddedCropViewController.swift
@@ -44,7 +44,6 @@ class EmbeddedCropViewController: UIViewController {
             
             var config = Mantis.Config()
             config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 1/2)
-            config.fixedRatioAnimationDuration = 0
             vc.config = config
             
             cropViewController = vc

--- a/Example/EmbeddedCropViewController.swift
+++ b/Example/EmbeddedCropViewController.swift
@@ -43,8 +43,8 @@ class EmbeddedCropViewController: UIViewController {
             vc.delegate = self
             
             var config = Mantis.Config()
-            config.ratioOptions = [.original, .square, .custom]
-            config.addCustomRatio(byVerticalWidth: 1, andVerticalHeight: 2)
+            config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 1/2)
+            config.fixedRatioAnimationDuration = 0
             vc.config = config
             
             cropViewController = vc

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -205,9 +205,14 @@ public class CropViewController: UIViewController {
         if (cropView.viewModel.aspectRatio != CGFloat(ratio)) {
             cropView.viewModel.aspectRatio = CGFloat(ratio)
             
-            UIView.animate(withDuration: config.fixedRatioAnimationDuration) {
+            if case .alwaysUsingOnePresetFixedRatio = config.presetFixedRatioType {
                 self.cropView.setFixedRatioCropBox()
+            } else {
+                UIView.animate(withDuration: 0.5) {
+                    self.cropView.setFixedRatioCropBox()
+                }
             }
+            
         }
     }
     

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -205,7 +205,7 @@ public class CropViewController: UIViewController {
         if (cropView.viewModel.aspectRatio != CGFloat(ratio)) {
             cropView.viewModel.aspectRatio = CGFloat(ratio)
             
-            UIView.animate(withDuration: 0.5) {
+            UIView.animate(withDuration: config.fixedRatioAnimationDuration) {
                 self.cropView.setFixedRatioCropBox()
             }
         }

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -120,6 +120,7 @@ public struct Config {
     public var ratioOptions: RatioOptions = .all
     public var presetFixedRatioType: PresetFixedRatioType = .canUseMultiplePresetFixedRatio
     public var showRotationDial = true
+    public var fixedRatioAnimationDuration: Double = 0.5
 
     public var cropToolbarConfig = CropToolbarConfig()
     

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -120,7 +120,6 @@ public struct Config {
     public var ratioOptions: RatioOptions = .all
     public var presetFixedRatioType: PresetFixedRatioType = .canUseMultiplePresetFixedRatio
     public var showRotationDial = true
-    public var fixedRatioAnimationDuration: Double = 0.5
 
     public var cropToolbarConfig = CropToolbarConfig()
     


### PR DESCRIPTION
Currently, if you load an embedded Mantis controller which is configured with a fixed ratio, there is an animation after the view loads:

![Nov-19-2020 11-01-55](https://user-images.githubusercontent.com/5530491/99658033-d8ee9300-2a56-11eb-843a-bc60b5821686.gif)

This PR makes the animation duration configurable, so you can set it to 0 and have the embedded controller load with the fixed ratio already set:

![Nov-19-2020 11-02-16](https://user-images.githubusercontent.com/5530491/99658078-e86ddc00-2a56-11eb-9c01-f3cdb410af48.gif)
