### PR TITLE
Fix build with BUILD_LIBRARY_FOR_DISTRIBUTION

### DIFF
--- a/Sources/Mantis/RotationDial/CGAngle.swift
+++ b/Sources/Mantis/RotationDial/CGAngle.swift
@@ -25,13 +25,14 @@ public class CGAngle: NSObject, Comparable {
         }
     }
 
-    @inlinable public init(radians: CGFloat) {
+    public init(radians: CGFloat) {
         self.radians = radians
     }
-    
-    @inlinable public init(degrees: CGFloat) {
-        radians = degrees / 180.0 * CGFloat.pi
+
+    public init(degrees: CGFloat) {
+        self.radians = degrees / 180.0 * CGFloat.pi
     }
+
     
     override public var description: String {
         return String(format: "%0.2f°", degrees)


### PR DESCRIPTION
If open pods project and set `BUILD_LIBRARY_FOR_DISTRIBUTION = YES`, this framework not gonna compile. error will say 
```
initializer for class 'CGAngle' is '@inlinable' and must delegate to another initializer
```

I was also surprised, but best guess is need to create `swiftinterface` in this mode, which has strict interface.