### PR TITLE
Remove CFBundleExecutable key from resources bundle

### DIFF
--- a/Sources/Mantis/Resources/Info.plist
+++ b/Sources/Mantis/Resources/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
-	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>


### PR DESCRIPTION
# Case
- Use Mantis via Cartage
- Upload build to TestFlight

TestFlight uploading will be failed with error message:
> ERROR ITMS-90535: "Unexpected CFBundleExecutable Key. The bundle at 'Payload/ApplicantHH.app/Frameworks/Mantis.framework/Resource.bundle' does not contain a bundle executable. If this bundle intentionally does not contain an executable, consider removing the CFBundleExecutable key from its Info.plist and using a CFBundlePackageType of BNDL. If this bundle is part of a third-party framework, consider contacting the developer of the framework for an update to address this issue."

# Solution
Removing `CFBundleExecutable` from resources bundle, whic was added in prevous PR: https://github.com/guoyingtao/Mantis/pull/84