### PR TITLE
fix warning: use 'AnyObject' instead 'class'

### DIFF
--- a/Example/ImagePicker.swift
+++ b/Example/ImagePicker.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public protocol ImagePickerDelegate: class {
+public protocol ImagePickerDelegate: AnyObject {
     func didSelect(image: UIImage?)
 }
 

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-protocol CropViewDelegate: class {
+protocol CropViewDelegate: AnyObject {
     func cropViewDidBecomeResettable(_ cropView: CropView)
     func cropViewDidBecomeUnResettable(_ cropView: CropView)
     func cropViewDidBeginResize(_ cropView: CropView)

--- a/Sources/Mantis/CropViewController/CropToolbarProtocol.swift
+++ b/Sources/Mantis/CropViewController/CropToolbarProtocol.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public protocol CropToolbarDelegate: class {
+public protocol CropToolbarDelegate: AnyObject {
     func didSelectCancel()
     func didSelectCrop()
     func didSelectCounterClockwiseRotate()

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -24,7 +24,7 @@
 
 import UIKit
 
-public protocol CropViewControllerDelegate: class {
+public protocol CropViewControllerDelegate: AnyObject {
     func cropViewControllerDidCrop(_ cropViewController: CropViewController,
                                    cropped: UIImage, transformation: Transformation)
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage)


### PR DESCRIPTION
Here's a warning.
`Using 'class' keyword for protocol inheritance is deprecated; use 'AnyObject' instead`
And i'm bit of cleanliness, i don't want any warning in my code, so after learn about 'class' and 'AnyObject', i choose fix this warning.