### PR TITLE
Cleanup Orientation code

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -201,7 +201,7 @@ public class CropViewController: UIViewController {
     }    
     
     @objc func rotated() {
-        let currentOrientation = Orientation.orientation
+        let currentOrientation = Orientation.interfaceOrientation
         
         guard currentOrientation != .unknown else { return }
         guard currentOrientation != orientation else { return }

--- a/Sources/Mantis/Helpers/Orientation.swift
+++ b/Sources/Mantis/Helpers/Orientation.swift
@@ -7,70 +7,61 @@
 import UIKit
 
 public struct Orientation {
-    public static var orientation: UIInterfaceOrientation {
-        get {
-            if #available(iOS 13, macOS 10.13, *) {
-                return (UIApplication.shared.windows.first?.windowScene?.interfaceOrientation)!
-            } else {
-                return UIApplication.shared.statusBarOrientation
-            }
+    
+    static var interfaceOrientation: UIInterfaceOrientation {
+        if #available(iOS 13, macOS 10.13, *) {
+            return (application.windows.first?.windowScene?.interfaceOrientation)!
+        } else {
+            return application.statusBarOrientation
         }
     }
     
-    // indicate current device is in the LandScape orientation
+    static var deviceOrientation: UIDeviceOrientation? {
+        device.orientation.isValidInterfaceOrientation
+            ? device.orientation
+            : nil
+    }
+    
+    
+    private static var application: UIApplication { .shared }
+    
+    private static var device: UIDevice { .current }
+    
+    
+    /**
+     Whether or not the device is in landscape orientation.
+     */
     public static var isLandscape: Bool {
-        get {
-            if #available(iOS 13, macOS 10.13, *) {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation.isLandscape
-                    : (UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isLandscape)!
-            } else {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation.isLandscape
-                    : UIApplication.shared.statusBarOrientation.isLandscape
-            }
-        }
-    }
-    // indicate current device is in the Portrait orientation
-    public static var isPortrait: Bool {
-        get {
-            if #available(iOS 13, macOS 10.13, *) {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation.isPortrait
-                    : (UIApplication.shared.windows.first?.windowScene?.interfaceOrientation.isPortrait)!
-            } else {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation.isPortrait
-                    : UIApplication.shared.statusBarOrientation.isPortrait
-            }
-        }
+        device.orientation.isValidInterfaceOrientation
+            ? device.orientation.isLandscape
+            : interfaceOrientation.isLandscape
+        
     }
     
+    /**
+     Whether or not the device is in landscape left orientation.
+     */
     public static var isLandscapeLeft: Bool {
-        get {
-            if #available(iOS 13, macOS 10.13, *) {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation == .landscapeLeft
-                    : (UIApplication.shared.windows.first?.windowScene?.interfaceOrientation)! == .landscapeLeft
-            } else {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation == .landscapeLeft
-                    : UIApplication.shared.statusBarOrientation == .landscapeLeft
-            }
-        }
+        device.orientation.isValidInterfaceOrientation
+            ? device.orientation == .landscapeLeft
+            : interfaceOrientation == .landscapeLeft
     }
     
+    /**
+     Whether or not the device is in landscape right orientation.
+     */
     public static var isLandscapeRight: Bool {
-        get {
-            if #available(iOS 13, macOS 10.13, *) {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation == .landscapeRight
-                    : (UIApplication.shared.windows.first?.windowScene?.interfaceOrientation)! == .landscapeRight
-            } else {
-                return UIDevice.current.orientation.isValidInterfaceOrientation
-                    ? UIDevice.current.orientation == .landscapeRight
-                    : UIApplication.shared.statusBarOrientation == .landscapeRight
-            }
-        }
+        device.orientation.isValidInterfaceOrientation
+            ? device.orientation == .landscapeRight
+            : interfaceOrientation == .landscapeRight
+    }
+    
+    /**
+     Whether or not the device is in portrait orientation.
+     */
+    public static var isPortrait: Bool {
+        device.orientation.isValidInterfaceOrientation
+            ? device.orientation.isPortrait
+            : interfaceOrientation.isPortrait
     }
 }


### PR DESCRIPTION
While working on the Xcode 13 beta 3 issue (#131), I cleaned up the Orientation code a bit, to make it easier to work with.

The force unwrap and iOS 13 check are now contained within extracted properties, to avoid having to repeat the same unwrap logic in each property.


---
@guoyingtao I closed the previous PR and created a new one from a dedicated feature branch with this single fix. The rest of the Xcode 13 fixes aren't needed, since Apple reverted the change that forced me to add them.