### PR TITLE
fixed cropViewControllerDidCrop delegate method

### DIFF
--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -75,7 +75,7 @@ struct ImageCropper: UIViewControllerRepresentable {
             self.parent = parent
         }
         
-        func cropViewControllerDidCrop(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation) {
+        func cropViewControllerDidCrop(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation, cropInfo: CropInfo) {
             parent.image = cropped
             print("transformation is \(transformation)")
             parent.presentationMode.wrappedValue.dismiss()


### PR DESCRIPTION
The cropViewControllerDidCrop delegate method was not updated to the latest, so the "Done" button does not work in the example. 