### PR TITLE
Reproducer for Crop Box staying out of image.

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -98,12 +98,18 @@ class ViewController: UIViewController, CropViewControllerDelegate {
             return
         }
         
-        let config = Mantis.Config()
+        var config = Mantis.Config()
+        config.showAttachedCropToolbar = true
+        config.cropViewConfig.showRotationDial = false
+        config.cropViewConfig.cropMaskVisualEffectType = .light
+        config.cropToolbarConfig.toolbarButtonOptions = []
+        config.ratioOptions = []
+        config.cropViewConfig.cropShapeType = .circle(maskOnly: true)
         
         let cropViewController = Mantis.cropViewController(image: image, config: config)
         cropViewController.modalPresentationStyle = .fullScreen
         cropViewController.delegate = self
-        cropViewController.config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 16.0 / 9.0)
+        cropViewController.config.addCustomRatio(byVerticalWidth: 1, andVerticalHeight: 1)
         present(cropViewController, animated: true)
     }
         
@@ -260,6 +266,7 @@ class ViewController: UIViewController, CropViewControllerDelegate {
                                    cropInfo: CropInfo) {
         print("transformation is \(transformation)")
         print("cropInfo is \(cropInfo)")
+        print("cropped image size: \(cropped.size)")
         croppedImageView.image = cropped
         dismiss(animated: true)
     }


### PR DESCRIPTION
1. Click on Select from album
2. Click Camera roll
3. Select the first waterfall picture
4. Click on Choose
5. Click on AlwaysOnePresetRatio

now when zooming in on the simulator with the option key pressed down, you can see at the end of the video sometimes the crop box just stays out of the image and does not bounce back. Here's a video:

https://user-images.githubusercontent.com/5759366/183083086-cd571a0e-8c3b-4872-ab19-c7f8ef583327.mp4

and a screenshot:

<img width="300" alt="Screen Shot 2022-08-05 at 15 02 35" src="https://user-images.githubusercontent.com/5759366/183083154-4fa1e0ee-34f9-4990-9d03-299a2841f72f.png">

