### PR TITLE
Reproducer for wrong aspect ratio.

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -98,20 +98,32 @@ class ViewController: UIViewController, CropViewControllerDelegate {
             return
         }
         
-        let config = Mantis.Config()
+        UIGraphicsBeginImageContext(CGSize(width: image.size.width / 1.1, height: image.size.height / 1.1))
+        image.draw(in: CGRect(x: 0, y: 0, width: image.size.width / 1.1, height: image.size.height / 1.1))
+        let scaledImage = UIGraphicsGetImageFromCurrentImageContext()!
+        UIGraphicsEndImageContext()
         
-        let cropViewController = Mantis.cropViewController(image: image, config: config)
-        cropViewController.modalPresentationStyle = .fullScreen
+        var config = Mantis.Config()
+        config.showAttachedCropToolbar = true
+        config.cropViewConfig.showRotationDial = false
+        config.cropViewConfig.cropMaskVisualEffectType = .light
+        config.cropToolbarConfig.toolbarButtonOptions = []
+        config.ratioOptions = []
+        config.cropViewConfig.cropShapeType = .circle(maskOnly: true)
+        
+        let navigationController = UINavigationController()
+        let cropViewController = Mantis.cropViewController(image: scaledImage, config: config)
         cropViewController.delegate = self
-        cropViewController.config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 16.0 / 9.0)
-        present(cropViewController, animated: true)
+        cropViewController.config.addCustomRatio(byVerticalWidth: 1, andVerticalHeight: 1)
+        navigationController.setViewControllers([cropViewController], animated: true)
+        present(navigationController, animated: true)
     }
         
     @IBAction func customizedCropToolbarButtonTouched(_ sender: Any) {
         guard let image = image else {
             return
         }
-        var config = Mantis.Config()        
+        var config = Mantis.Config()
         config.cropToolbarConfig = CropToolbarConfig()
         config.cropToolbarConfig.backgroundColor = .red
         config.cropToolbarConfig.foregroundColor = .white
@@ -260,6 +272,7 @@ class ViewController: UIViewController, CropViewControllerDelegate {
                                    cropInfo: CropInfo) {
         print("transformation is \(transformation)")
         print("cropInfo is \(cropInfo)")
+        print("cropped image size: \(cropped.size)")
         croppedImageView.image = cropped
         dismiss(animated: true)
     }


### PR DESCRIPTION
1. Select AlwaysUseOnePresetRatio
2. Wiggle around, zoom in and out using option + trackpack

https://user-images.githubusercontent.com/5759366/183085282-3f2ca245-26d1-46c2-86ab-4fada83230e8.mp4

Now when pressing `Done`, I'd expect to get a picture with an aspect ratio of 1:1, however I almost always get:

```
cropped image size: (3317.0, 3316.0)
```

There seems to be an off by one error somewhere.