### PR TITLE
fix: use optional CropToolbarProtocol for CropToolbarDelegate

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -376,47 +376,47 @@ extension CropViewController: CropViewDelegate {
 }
 
 extension CropViewController: CropToolbarDelegate {
-    public func didSelectHorizontallyFlip(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectHorizontallyFlip(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleHorizontallyFlip()
     }
     
-    public func didSelectVerticallyFlip(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectVerticallyFlip(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleVerticallyFlip()
     }
     
-    public func didSelectCancel(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectCancel(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleCancel()
     }
     
-    public func didSelectCrop(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectCrop(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleCrop()
     }
     
-    public func didSelectCounterClockwiseRotate(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectCounterClockwiseRotate(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleRotate(withRotateType: .counterClockwise)
     }
     
-    public func didSelectClockwiseRotate(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectClockwiseRotate(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleRotate(withRotateType: .clockwise)
     }
     
-    public func didSelectReset(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectReset(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleReset()
     }
     
-    public func didSelectSetRatio(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectSetRatio(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleSetRatio()
     }
     
-    public func didSelectRatio(_ cropToolbar: CropToolbarProtocol, ratio: Double) {
+    public func didSelectRatio(_ cropToolbar: CropToolbarProtocol? = nil, ratio: Double) {
         setFixedRatio(ratio)
     }
     
-    public func didSelectFreeRatio(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectFreeRatio(_ cropToolbar: CropToolbarProtocol? = nil) {
         setFreeRatio()
     }
     
-    public func didSelectAlterCropper90Degree(_ cropToolbar: CropToolbarProtocol) {
+    public func didSelectAlterCropper90Degree(_ cropToolbar: CropToolbarProtocol? = nil) {
         handleAlterCropper90Degree()
     }    
 }

--- a/Sources/Mantis/Protocols/CropToolbarProtocol.swift
+++ b/Sources/Mantis/Protocols/CropToolbarProtocol.swift
@@ -11,17 +11,17 @@ import UIKit
     Inside Mantis, CropViewController implements all delegate methods 
  */
 public protocol CropToolbarDelegate: AnyObject {
-    func didSelectCancel(_ cropToolbar: CropToolbarProtocol)
-    func didSelectCrop(_ cropToolbar: CropToolbarProtocol)
-    func didSelectCounterClockwiseRotate(_ cropToolbar: CropToolbarProtocol)
-    func didSelectClockwiseRotate(_ cropToolbar: CropToolbarProtocol)
-    func didSelectReset(_ cropToolbar: CropToolbarProtocol)
-    func didSelectSetRatio(_ cropToolbar: CropToolbarProtocol)
-    func didSelectRatio(_ cropToolbar: CropToolbarProtocol, ratio: Double)
-    func didSelectFreeRatio(_ cropToolbar: CropToolbarProtocol)
-    func didSelectAlterCropper90Degree(_ cropToolbar: CropToolbarProtocol)
-    func didSelectHorizontallyFlip(_ cropToolbar: CropToolbarProtocol)
-    func didSelectVerticallyFlip(_ cropToolbar: CropToolbarProtocol)
+    func didSelectCancel(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectCrop(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectCounterClockwiseRotate(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectClockwiseRotate(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectReset(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectSetRatio(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectRatio(_ cropToolbar: CropToolbarProtocol?, ratio: Double)
+    func didSelectFreeRatio(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectAlterCropper90Degree(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectHorizontallyFlip(_ cropToolbar: CropToolbarProtocol?)
+    func didSelectVerticallyFlip(_ cropToolbar: CropToolbarProtocol?)
 }
 
 public protocol CropToolbarIconProvider: AnyObject {


### PR DESCRIPTION
Normally if a user want a custom crop tool bar, the tool bar need to delegate operations to CropViewController. For some users who do not want the attached tool bar but still want to use these delegate functions, there is no need to pass a CropToolbarProtocol instance. So I change it to optional