### PR TITLE
feat: add 4 edge line handles on CropAuxiliaryIndicatorView

### DIFF
--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -156,7 +156,7 @@ class CropView: UIView {
             cropAuxiliaryIndicatorView.gridLineNumberType = .crop
             cropAuxiliaryIndicatorView.setGrid(hidden: false, animated: true)
         case .touchCropboxHandle(let tappedEdge):
-            cropAuxiliaryIndicatorView.handleEdgeTouched(with: tappedEdge)
+            cropAuxiliaryIndicatorView.handleCornerHandleTouched(with: tappedEdge)
             rotationDial?.isHidden = true
             cropMaskViewManager.showDimmingBackground(animated: true)
         case .touchRotationBoard:

--- a/Sources/Mantis/Protocols/CropOverlayViewProtocol.swift
+++ b/Sources/Mantis/Protocols/CropOverlayViewProtocol.swift
@@ -27,10 +27,9 @@ enum GridLineNumberType {
 protocol CropAuxiliaryIndicatorViewProtocol: UIView {
     var gridLineNumberType: GridLineNumberType { get set }
     var gridHidden: Bool { get set }
-    var gridColor: UIColor { get set }
     
     func setGrid(hidden: Bool, animated: Bool)
     func hideGrid()
-    func handleEdgeTouched(with tappedEdge: CropViewOverlayEdge)
+    func handleCornerHandleTouched(with tappedEdge: CropViewOverlayEdge)
     func handleEdgeUntouched()
 }


### PR DESCRIPTION
To be consistent with the editor of current iOS Photo.app

### Now

<img width="426" alt="image" src="https://user-images.githubusercontent.com/26723384/215389958-db94d439-4e24-4aee-9c35-1efb180ce9f0.png">

### Before

<img width="376" alt="image" src="https://user-images.githubusercontent.com/26723384/215390535-6a49b7c7-be7c-4cdc-9fd8-e7b0355ba454.png">

