### PR TITLE
fix: solve the gesture conflict for rotation dial

### DIFF
--- a/Sources/Mantis/RotationDial/RotationDial+Touches.swift
+++ b/Sources/Mantis/RotationDial/RotationDial+Touches.swift
@@ -42,4 +42,12 @@ extension RotationDial {
         didFinishedRotate()
         viewModel.touchPoint = nil
     }
+    
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        if gestureRecognizer is UIPanGestureRecognizer {
+            return false
+        }
+        
+        return true
+    }
 }


### PR DESCRIPTION
Solve the gesture conflict for rotation dial then CropViewController is presented as a non-fullscreen mode