### PR TITLE
Add missing function to conform

### DIFF
--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -92,6 +92,9 @@ struct ImageCropper: UIViewControllerRepresentable {
         
         func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo) {
         }
+        
+        func cropViewControllerDidImageTransformed(_ cropViewController: CropViewController) {
+        }
     }
     
     func makeCoordinator() -> Coordinator {


### PR DESCRIPTION
CropViewControllerDelegate has the `cropViewControllerDidImageTransformed()` function that wasn't present in this example which causes a build error