### PR TITLE
refactor: use Core Graphics instead of UIViews to draw overlay indicator lines

### DIFF
--- a/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
+++ b/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
@@ -19,21 +19,19 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
 
     private var hintLine = UIView()
     private var tappedEdge: CropViewAuxiliaryIndicatorHandleType = .none
-    private var gridColor = UIColor(white: 0.8, alpha: 1)
+    private var gridMainColor = UIColor.white
+    private var gridSecondaryColor = UIColor.lightGray
     
     var cropBoxHotAreaUnit: CGFloat = 42
     
-    var gridHidden = true
-
-    var gridLineNumberType: GridLineNumberType = .crop {
+    var gridHidden = true {
         didSet {
-            setupGridLines()
-            layoutGridLines()
+            setNeedsDisplay()
         }
     }
+
+    var gridLineNumberType: GridLineNumberType = .crop
     
-    private var horizontalGridLines: [UIView] = []
-    private var verticalGridLines: [UIView] = []
     private var borderLine: UIView = UIView()
     private var cornerHandles: [UIView] = []
     private var edgeLineHandles: [UIView] = []
@@ -52,12 +50,14 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
     init(frame: CGRect, cropBoxHotAreaUnit: CGFloat) {
         super.init(frame: frame)
         clipsToBounds = false
+        backgroundColor = .clear
         self.cropBoxHotAreaUnit = cropBoxHotAreaUnit
         setup()
     }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        backgroundColor = .clear
     }
     
     private func createNewLine() -> UIView {
@@ -82,7 +82,6 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
             edgeLineHandles.append(createNewLine())
         }
         
-        setupGridLines()
         hintLine.backgroundColor = boarderHintColor
         
         setupAccessibilityHelperViews()
@@ -107,6 +106,36 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
         return result
     }
     
+    override func draw(_ rect: CGRect) {
+        if !gridHidden {
+            let helpLineNumber = gridLineNumberType.getHelpLineNumber()
+            
+            for index in 0..<helpLineNumber {
+                if gridLineNumberType == .rotate && (index + 1) % 3 != 0 {
+                    gridSecondaryColor.setStroke()
+                } else {
+                    gridMainColor.setStroke()
+                }
+                
+                let horizontalPath = UIBezierPath()
+                horizontalPath.lineWidth = 1
+                let horizontalY = CGFloat(index + 1) * frame.height / CGFloat(helpLineNumber + 1)
+                horizontalPath.move(to: CGPoint(x: 0,
+                                                y: horizontalY))
+                horizontalPath.addLine(to: CGPoint(x: frame.width, y: horizontalY))
+                horizontalPath.stroke()
+                
+                let verticalPath = UIBezierPath()
+                verticalPath.lineWidth = 1
+                let horizontalX = CGFloat(index + 1) * frame.width / CGFloat(helpLineNumber + 1)
+                verticalPath.move(to: CGPoint(x: horizontalX,
+                                              y: 0))
+                verticalPath.addLine(to: CGPoint(x: horizontalX, y: frame.height))
+                verticalPath.stroke()
+            }
+        }
+    }
+    
     private func layoutLines() {
         guard bounds.isEmpty == false else {
             return
@@ -115,55 +144,9 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
         layoutOuterLines()
         layoutCornerHandles()
         layoutEdgeLineHandles()
-        layoutGridLines()
-        setGridShowStatus()
         layoutAccessibilityHelperViews()
     }
-    
-    private func setGridShowStatus() {
-        horizontalGridLines.forEach { $0.alpha = gridHidden ? 0 : 1 }
-        verticalGridLines.forEach { $0.alpha = gridHidden ? 0 : 1 }
-    }
-    
-    private func layoutGridLines() {
-        let helpLineNumber = gridLineNumberType.getHelpLineNumber()
-        for index in 0..<helpLineNumber {
-            horizontalGridLines[index].frame = CGRect(x: 0,
-                                                      y: CGFloat(index + 1) * frame.height / CGFloat(helpLineNumber + 1),
-                                                      width: frame.width,
-                                                      height: 1)
-            verticalGridLines[index].frame = CGRect(x: CGFloat(index + 1) * frame.width / CGFloat(helpLineNumber + 1),
-                                                    y: 0,
-                                                    width: 1,
-                                                    height: frame.height)
-        }
-    }
-    
-    private func setupGridLines() {
-        setupVerticalGridLines()
-        setupHorizontalGridLines()
-    }
-    
-    private func setupHorizontalGridLines() {
-        horizontalGridLines.forEach { $0.removeFromSuperview() }
-        horizontalGridLines.removeAll()
-        for _ in 0..<gridLineNumberType.getHelpLineNumber() {
-            let view = createNewLine()
-            view.backgroundColor = gridColor
-            horizontalGridLines.append(view)
-        }
-    }
-    
-    private func setupVerticalGridLines() {
-        verticalGridLines.forEach { $0.removeFromSuperview() }
-        verticalGridLines.removeAll()
-        for _ in 0..<gridLineNumberType.getHelpLineNumber() {
-            let view = createNewLine()
-            view.backgroundColor = gridColor
-            verticalGridLines.append(view)
-        }
-    }
-    
+        
     private func layoutOuterLines() {
         borderLine.frame = CGRect(x: -borderThickness,
                                   y: -borderThickness,
@@ -238,29 +221,7 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
             }
         }
     }
-    
-    func setGrid(hidden: Bool, animated: Bool = false) {
-        self.gridHidden = hidden
-        
-        func setGridLinesShowStatus () {
-            horizontalGridLines.forEach { $0.alpha = hidden ? 0 : 1 }
-            verticalGridLines.forEach { $0.alpha = hidden ? 0 : 1}
-        }
-        
-        if animated {
-            let duration = hidden ? 0.35 : 0.2
-            UIView.animate(withDuration: duration) {
-                setGridLinesShowStatus()
-            }
-        } else {
-            setGridLinesShowStatus()
-        }
-    }
-    
-    func hideGrid() {
-        gridLineNumberType = .none
-    }
-    
+            
     func handleIndicatorHandleTouched(with tappedEdge: CropViewAuxiliaryIndicatorHandleType) {
         guard tappedEdge != .none  else {
             return
@@ -268,7 +229,7 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
         
         self.tappedEdge = tappedEdge
         
-        setGrid(hidden: false, animated: true)
+        gridHidden = false
         gridLineNumberType = .crop
         
         func handleHintLine() {
@@ -310,7 +271,7 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
     }
     
     func handleEdgeUntouched() {
-        setGrid(hidden: true, animated: true)
+        gridHidden = true
         hintLine.removeFromSuperview()
         tappedEdge = .none
     }

--- a/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
+++ b/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
@@ -108,9 +108,9 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
     
     override func draw(_ rect: CGRect) {
         if !gridHidden {
-            let helpLineNumber = gridLineNumberType.getHelpLineNumber()
+            let indicatorLineNumber = gridLineNumberType.getIndicatorLineNumber()
             
-            for index in 0..<helpLineNumber {
+            for index in 0..<indicatorLineNumber {
                 if gridLineNumberType == .rotate && (index + 1) % 3 != 0 {
                     gridSecondaryColor.setStroke()
                 } else {
@@ -120,11 +120,11 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
                 let indicatorLinePath = UIBezierPath()
                 indicatorLinePath.lineWidth = 1
                 
-                let horizontalY = CGFloat(index + 1) * frame.height / CGFloat(helpLineNumber + 1)
+                let horizontalY = CGFloat(index + 1) * frame.height / CGFloat(indicatorLineNumber + 1)
                 indicatorLinePath.move(to: CGPoint(x: 0, y: horizontalY))
                 indicatorLinePath.addLine(to: CGPoint(x: frame.width, y: horizontalY))
                 
-                let horizontalX = CGFloat(index + 1) * frame.width / CGFloat(helpLineNumber + 1)
+                let horizontalX = CGFloat(index + 1) * frame.width / CGFloat(indicatorLineNumber + 1)
                 indicatorLinePath.move(to: CGPoint(x: horizontalX, y: 0))
                 indicatorLinePath.addLine(to: CGPoint(x: horizontalX, y: frame.height))
                 

--- a/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
+++ b/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
@@ -117,21 +117,18 @@ class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtocol {
                     gridMainColor.setStroke()
                 }
                 
-                let horizontalPath = UIBezierPath()
-                horizontalPath.lineWidth = 1
-                let horizontalY = CGFloat(index + 1) * frame.height / CGFloat(helpLineNumber + 1)
-                horizontalPath.move(to: CGPoint(x: 0,
-                                                y: horizontalY))
-                horizontalPath.addLine(to: CGPoint(x: frame.width, y: horizontalY))
-                horizontalPath.stroke()
+                let indicatorLinePath = UIBezierPath()
+                indicatorLinePath.lineWidth = 1
                 
-                let verticalPath = UIBezierPath()
-                verticalPath.lineWidth = 1
+                let horizontalY = CGFloat(index + 1) * frame.height / CGFloat(helpLineNumber + 1)
+                indicatorLinePath.move(to: CGPoint(x: 0, y: horizontalY))
+                indicatorLinePath.addLine(to: CGPoint(x: frame.width, y: horizontalY))
+                
                 let horizontalX = CGFloat(index + 1) * frame.width / CGFloat(helpLineNumber + 1)
-                verticalPath.move(to: CGPoint(x: horizontalX,
-                                              y: 0))
-                verticalPath.addLine(to: CGPoint(x: horizontalX, y: frame.height))
-                verticalPath.stroke()
+                indicatorLinePath.move(to: CGPoint(x: horizontalX, y: 0))
+                indicatorLinePath.addLine(to: CGPoint(x: horizontalX, y: frame.height))
+                
+                indicatorLinePath.stroke()
             }
         }
     }

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -153,14 +153,14 @@ class CropView: UIView {
         case .touchImage:
             cropMaskViewManager.showDimmingBackground(animated: true)
             cropAuxiliaryIndicatorView.gridLineNumberType = .crop
-            cropAuxiliaryIndicatorView.setGrid(hidden: false, animated: true)
+            cropAuxiliaryIndicatorView.gridHidden = false
         case .touchCropboxHandle(let tappedEdge):
             cropAuxiliaryIndicatorView.handleIndicatorHandleTouched(with: tappedEdge)
             rotationDial?.isHidden = true
             cropMaskViewManager.showDimmingBackground(animated: true)
         case .touchRotationBoard:
             cropAuxiliaryIndicatorView.gridLineNumberType = .rotate
-            cropAuxiliaryIndicatorView.setGrid(hidden: false, animated: true)
+            cropAuxiliaryIndicatorView.gridHidden = false
             cropMaskViewManager.showDimmingBackground(animated: true)
         case .betweenOperation:
             cropAuxiliaryIndicatorView.handleEdgeUntouched()

--- a/Sources/Mantis/Protocols/CropAuxiliaryIndicatorViewProtocol.swift
+++ b/Sources/Mantis/Protocols/CropAuxiliaryIndicatorViewProtocol.swift
@@ -12,7 +12,7 @@ enum GridLineNumberType {
     case crop
     case rotate
     
-    func getHelpLineNumber() -> Int {
+    func getIndicatorLineNumber() -> Int {
         switch self {
         case .none:
             return 0

--- a/Sources/Mantis/Protocols/CropAuxiliaryIndicatorViewProtocol.swift
+++ b/Sources/Mantis/Protocols/CropAuxiliaryIndicatorViewProtocol.swift
@@ -29,8 +29,6 @@ protocol CropAuxiliaryIndicatorViewProtocol: UIView {
     var gridHidden: Bool { get set }
     var cropBoxHotAreaUnit: CGFloat { get set }
     
-    func setGrid(hidden: Bool, animated: Bool)
-    func hideGrid()
     func handleIndicatorHandleTouched(with tappedEdge: CropViewAuxiliaryIndicatorHandleType)
     func handleEdgeUntouched()
 }

--- a/Tests/MantisTests/CropAuxiliaryIndicatorViewTests.swift
+++ b/Tests/MantisTests/CropAuxiliaryIndicatorViewTests.swift
@@ -59,40 +59,7 @@ final class CropAuxiliaryIndicatorViewTests: XCTestCase {
         XCTAssertEqual(cropAuxiliaryIndicatorView.subviews.count, subviewCount + 1)
         XCTAssertEqual(cropAuxiliaryIndicatorView.gridLineNumberType, .crop)        
     }
-
-    func testHideGrid() {
-        cropAuxiliaryIndicatorView.gridLineNumberType = .crop
-        XCTAssertEqual(cropAuxiliaryIndicatorView.gridLineNumberType, .crop)
-        cropAuxiliaryIndicatorView.hideGrid()
-        XCTAssertEqual(cropAuxiliaryIndicatorView.gridLineNumberType, .none)
-    }
-    
-    func testSetGrid() {
-        cropAuxiliaryIndicatorView.setGrid(hidden: true)
-        XCTAssertTrue(cropAuxiliaryIndicatorView.gridHidden)
         
-        var visibleSubViewsCount = cropAuxiliaryIndicatorView.subviews.filter { $0.alpha == 1 }.count
-        
-        cropAuxiliaryIndicatorView.gridLineNumberType = .crop
-        cropAuxiliaryIndicatorView.setGrid(hidden: false)
-        XCTAssertFalse(cropAuxiliaryIndicatorView.gridHidden)
-        
-        var visibleSubViewsCount1 = cropAuxiliaryIndicatorView.subviews.filter { $0.alpha == 1 }.count
-        XCTAssertEqual(visibleSubViewsCount1, visibleSubViewsCount + 2 * 2)
-        
-        cropAuxiliaryIndicatorView.setGrid(hidden: true)
-        XCTAssertTrue(cropAuxiliaryIndicatorView.gridHidden)
-        
-        visibleSubViewsCount = cropAuxiliaryIndicatorView.subviews.filter { $0.alpha == 1 }.count
-        
-        cropAuxiliaryIndicatorView.gridLineNumberType = .rotate
-        cropAuxiliaryIndicatorView.setGrid(hidden: false)
-        XCTAssertFalse(cropAuxiliaryIndicatorView.gridHidden)
-        
-        visibleSubViewsCount1 = cropAuxiliaryIndicatorView.subviews.filter { $0.alpha == 1 }.count
-        XCTAssertEqual(visibleSubViewsCount1, visibleSubViewsCount + 2 * 8)
-    }
-    
     func testHandleCornerHandleTouched() {
         let subviewCount = cropAuxiliaryIndicatorView.subviews.count
         cropAuxiliaryIndicatorView.handleIndicatorHandleTouched(with: .none)


### PR DESCRIPTION
* use Core Graphics instead of UIViews to draw overlay indicator lines
* use two colors for rotating indicator lines

![Simulator Screen Recording - iPhone 14 Pro Max - 2023-03-13 at 16 16 31](https://user-images.githubusercontent.com/26723384/224644375-6640d573-b744-433e-8f7b-b0421832720b.gif)
