### PR TITLE
make CropRegion props public

### DIFF
--- a/Sources/Mantis/CropData.swift
+++ b/Sources/Mantis/CropData.swift
@@ -35,10 +35,10 @@ public typealias Transformation = (
 )
 
 public struct CropRegion: Equatable {
-    var topLeft: CGPoint
-    var topRight: CGPoint
-    var bottomLeft: CGPoint
-    var bottomRight: CGPoint
+    public var topLeft: CGPoint
+    public var topRight: CGPoint
+    public var bottomLeft: CGPoint
+    public var bottomRight: CGPoint
 }
 
 public typealias CropInfo = (


### PR DESCRIPTION
After changing CropRegion typealias into a struct it's properties are no longer accessible as they are internal. Code does not compile anymore.