### PR TITLE
fix: drop macOS support and update min support version to v12 for iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Mantis",
     defaultLocalization: "en",
-    platforms: [.iOS(.v11), .macOS(.v10_15)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(
             name: "Mantis",

--- a/Sources/Mantis/Helpers/Orientation.swift
+++ b/Sources/Mantis/Helpers/Orientation.swift
@@ -8,7 +8,7 @@ import UIKit
 
 public struct Orientation {
     static var interfaceOrientation: UIInterfaceOrientation {
-        if #available(iOS 13, macOS 10.13, *) {
+        if #available(iOS 13, *) {
             return application.windows.first?.windowScene?.interfaceOrientation ?? .portrait
         } else {
             return application.statusBarOrientation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated platform support: The package now supports only iOS 12 and above; macOS support has been removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->