### PR TITLE
Package // Add macCatalyst as a supported platform.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "Mantis",
     defaultLocalization: "en",
-    platforms: [.iOS(.v12)],
+    platforms: [.iOS(.v12), .macCatalyst(.v13)],
     products: [
         .library(
             name: "Mantis",


### PR DESCRIPTION
This solves the compilation issue when being imported into a Swift Package that supports macOS (AppKit) and macCatalyst.

PizzaHelper4HSR previously uses Mantis on macCatalyst and it was fine.

P.S.: This PR boosts the SPM configuration version to 5.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated minimum Swift tools version requirement to 5.5.
  - Added support for macCatalyst (minimum version 13) in addition to existing iOS support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->