### PR TITLE
fix: fix crop view displaying issue on iOS 26

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -187,6 +187,10 @@ open class CropViewController: UIViewController {
     override public func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         if initialLayout == false {
+            guard cropView.bounds.size != .zero else {
+                return
+            }
+            
             initialLayout = true
             view.layoutIfNeeded()
             cropView.resetComponents()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by preventing layout operations when the crop area has no valid size. This helps avoid potential errors during image cropping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->