### PR TITLE
SwiftUI: Support callback when crop is done

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ struct MyView: View {
 }
 ```
 
+> **Note:**  
+> - To start a crop operation programmatically, use the existing `action` binding(for `ImageCropperView`):  
+>   ```swift
+>   action = .crop
+>   ```
+> - To receive the result of the crop (success or failure), use the new `onCropCompleted` callback.  
+>   This is especially useful because cropping may not complete instantly in all cases, so relying on this callback ensures you update your UI only after the operation finishes.
+
 * The caller needs to conform CropViewControllerDelegate
 ```swift
 public protocol CropViewControllerDelegate: class {

--- a/Sources/Mantis/SwiftUIView/ImageCropper.swift
+++ b/Sources/Mantis/SwiftUIView/ImageCropper.swift
@@ -21,7 +21,7 @@ public enum CropAction {
 
 @available(iOS 13.0, *)
 public enum CropStatus {
-    case successed
+    case succeeded
     case failed
 }
 @available(iOS 13.0, *)
@@ -112,17 +112,20 @@ public struct ImageCropperView: UIViewControllerRepresentable {
             DispatchQueue.main.async {
                 self.isProcessingAction = false
                 self.parent.onDismiss()
-                self.parent.onCropCompleted(.successed)
+                self.parent.onCropCompleted(.succeeded)
             }
         }
         
         public func cropViewControllerDidCancel(_ cropViewController: Mantis.CropViewController, original: UIImage) {
-            parent.onDismiss()
+            DispatchQueue.main.async {
+                self.parent.onDismiss()
+            }
         }
         
-        public func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {
+        public func cropViewControllerDidFailToCrop(_ cropViewController: Mantis.CropViewController, original: UIImage) {
             DispatchQueue.main.async {
                 self.isProcessingAction = false
+                self.lastProcessedAction = nil
                 self.parent.onDismiss()
                 self.parent.onCropCompleted(.failed)
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a callback to notify when a crop operation completes, indicating success or failure.
  * Introduced a new status to distinguish between successful and failed crop attempts.

* **Documentation**
  * Updated usage instructions to explain how to start cropping programmatically and handle crop completion with the new callback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->