### PR TITLE
fix: publishing changes from not main thread

### DIFF
--- a/Sources/Mantis/SwiftUIView/ImageCropper.swift
+++ b/Sources/Mantis/SwiftUIView/ImageCropper.swift
@@ -105,11 +105,11 @@ public struct ImageCropperView: UIViewControllerRepresentable {
         public func cropViewControllerDidCrop(_ cropViewController: Mantis.CropViewController, cropped: UIImage, transformation: Transformation, cropInfo: CropInfo) {
             isProcessingAction = true
             
-            parent.image = cropped
-            parent.transformation = transformation
-            parent.cropInfo = cropInfo
-            
             DispatchQueue.main.async {
+                self.parent.image = cropped
+                self.parent.transformation = transformation
+                self.parent.cropInfo = cropInfo
+                
                 self.isProcessingAction = false
                 self.parent.onDismiss()
                 self.parent.onCropCompleted(.succeeded)


### PR DESCRIPTION
fixes [SwiftUI: Warning “Publishing changes from within view updates is not allowed” in ImageCropperView.Coordinator](https://github.com/guoyingtao/Mantis/issues/473)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent UI glitches and inconsistent crop previews during image transformations and completion.
  * Ensured callbacks (dismiss and completion) fire reliably without delay.

* **Performance/Stability**
  * Improved responsiveness and visual consistency in the image cropping experience by processing UI-bound updates on the main thread.
  * Reduced risk of freezes or delayed state updates while editing and finalizing crops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->