### PR TITLE
fix: SwiftUI warning by dispatching state updates to main thread

### DIFF
--- a/Sources/Mantis/SwiftUIView/ImageCropper.swift
+++ b/Sources/Mantis/SwiftUIView/ImageCropper.swift
@@ -104,12 +104,10 @@ public struct ImageCropperView: UIViewControllerRepresentable {
         
         public func cropViewControllerDidCrop(_ cropViewController: Mantis.CropViewController, cropped: UIImage, transformation: Transformation, cropInfo: CropInfo) {
             isProcessingAction = true
-            
-            parent.image = cropped
-            parent.transformation = transformation
-            parent.cropInfo = cropInfo
-            
             DispatchQueue.main.async {
+                self.parent.image = cropped
+                self.parent.transformation = transformation
+                self.parent.cropInfo = cropInfo
                 self.isProcessingAction = false
                 self.parent.onDismiss()
                 self.parent.onCropCompleted(.succeeded)


### PR DESCRIPTION
Moved all binding assignments  inside `DispatchQueue.main.async` in ImageCropperView

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved occasional issues where cropped images or related info might not update reliably.
  * Fixed rare UI glitches and potential crashes when completing a crop action.
* **Performance**
  * Improved responsiveness and stability during crop completion and dismissal.
* **Chores**
  * Minor internal adjustments to ensure updates occur consistently, enhancing overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->