### PR TITLE
fix: fix crop view displaying issue on iOS 26

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -422,6 +422,7 @@ extension CropViewController {
         guard config.showAttachedCropToolbar else {
             stackView?.removeArrangedSubview(cropStackView)
             stackView?.addArrangedSubview(cropStackView)
+            view.layoutIfNeeded()
             return
         }
         


### PR DESCRIPTION
**Title**

Fix crop view not displaying when showAttachedCropToolbar = false on iOS 26

**Description**

This PR fixes the issue where the crop view was not displayed when showAttachedCropToolbar was set to false.
On iOS 26, the view hierarchy was not properly updated in this case, resulting in an empty screen.

**Change:**
Added a call to view.layoutIfNeeded() after updating the stack view to ensure the crop view is properly laid out.

**Related Issue**

[Fixes #465](https://github.com/guoyingtao/Mantis/issues/465)