### PR TITLE
Wrap iOS 26 API with #if compiler(>=6.2) for Xcode 16 compatibility

### DIFF
--- a/Sources/Mantis/CropView/CropWorkbenchView.swift
+++ b/Sources/Mantis/CropView/CropWorkbenchView.swift
@@ -44,12 +44,14 @@ final class CropWorkbenchView: UIScrollView {
         
         isAccessibilityElement = false
         
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             topEdgeEffect.isHidden = true
             bottomEdgeEffect.isHidden = true
             leftEdgeEffect.isHidden = true
             rightEdgeEffect.isHidden = true
         }
+        #endif
     }
     
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

- Wraps the iOS 26 `UIScrollView` edge effect properties (`topEdgeEffect`, `bottomEdgeEffect`, `leftEdgeEffect`, `rightEdgeEffect`) with `#if compiler(>=6.2)` to maintain backward compatibility with Xcode 16.x
- The `#available(iOS 26.0, *)` runtime check alone is not sufficient — the compiler still needs to resolve these symbols at build time, which fails on Xcode 16.x (iOS 18 SDK)
- `#if compiler(>=6.2)` ensures the block is only compiled with Swift 6.2+ (Xcode 26), keeping the library buildable on older Xcode versions

Fixes the build break introduced in #488.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced compiler compatibility for crop view functionality. Updated conditional compilation checks to support Swift compiler 6.2 and later while preserving existing iOS compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->