### PR TITLE
Wrap Liquid Glass APIs with #if compiler(>=6.2) for Xcode 16 compatibility

### DIFF
--- a/Sources/Mantis/CropViewController/CropToolbar.swift
+++ b/Sources/Mantis/CropViewController/CropToolbar.swift
@@ -110,12 +110,14 @@ public final class CropToolbar: UIView, CropToolbarProtocol {
     private var optionButtonStackView: UIStackView?
     
     // MARK: - Liquid Glass (iOS 26+)
+    #if compiler(>=6.2)
     private var glassStackView: UIStackView?
     private var toolGroupContainerView: UIVisualEffectView?
     private var glassWrapperMap: [ObjectIdentifier: UIVisualEffectView] = [:]
     private var toolGroupHeightConstraint: NSLayoutConstraint?
     private var toolGroupWidthConstraint: NSLayoutConstraint?
-    
+    #endif
+
     private var autoAdjustButtonActive = false {
         didSet {
             if autoAdjustButtonActive {
@@ -193,20 +195,26 @@ public final class CropToolbar: UIView, CropToolbarProtocol {
             addButtonsToContainer(button: cropButton)
         }
         
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             applyLiquidGlassEffect()
         }
+        #endif
     }
     
     public override var intrinsicContentSize: CGSize {
         let superSize = super.intrinsicContentSize
         
         let glassExtraPadding: CGFloat
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             glassExtraPadding = 16
         } else {
             glassExtraPadding = 0
         }
+        #else
+        glassExtraPadding = 0
+        #endif
 
         if Orientation.treatAsPortrait {
             return CGSize(width: superSize.width, height: config.heightForVerticalOrientation + glassExtraPadding)
@@ -228,9 +236,11 @@ public final class CropToolbar: UIView, CropToolbarProtocol {
             optionButtonStackView?.layoutMargins = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
         }
         
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *) {
             adjustGlassLayoutForOrientation()
         }
+        #endif
     }
 
     public func handleFixedRatioSetted(ratio: Double) {
@@ -243,27 +253,37 @@ public final class CropToolbar: UIView, CropToolbarProtocol {
 
     public func handleCropViewDidBecomeResettable() {
         resetButton?.isHidden = false
+        #if compiler(>=6.2)
         glassWrapper(for: resetButton)?.isHidden = false
         updateToolGroupVisibilityIfNeeded()
+        #endif
     }
 
     public func handleCropViewDidBecomeUnResettable() {
         resetButton?.isHidden = true
+        #if compiler(>=6.2)
         glassWrapper(for: resetButton)?.isHidden = true
         updateToolGroupVisibilityIfNeeded()
+        #endif
     }
-    
+
     public func handleImageAutoAdjustable() {
         autoAdjustButton.isHidden = false
+        #if compiler(>=6.2)
         glassWrapper(for: autoAdjustButton)?.isHidden = false
         updateToolGroupVisibilityIfNeeded()
+        #endif
     }
-    
+
     public func handleImageNotAutoAdjustable() {
         autoAdjustButton.isHidden = true
+        #if compiler(>=6.2)
         glassWrapper(for: autoAdjustButton)?.isHidden = true
+        #endif
         autoAdjustButtonActive = false
+        #if compiler(>=6.2)
         updateToolGroupVisibilityIfNeeded()
+        #endif
     }
 }
 
@@ -414,11 +434,12 @@ extension CropToolbar {
         }
     }
     
+    #if compiler(>=6.2)
     private func glassWrapper(for button: UIButton?) -> UIVisualEffectView? {
         guard let button = button else { return nil }
         return glassWrapperMap[ObjectIdentifier(button)]
     }
-    
+
     /// Hides/shows the tool group capsule based on whether any of its
     /// arranged subviews are visible.  Called after changing individual
     /// button visibility so an empty glass pill is never left on screen.
@@ -428,12 +449,14 @@ extension CropToolbar {
                   .first(where: { $0 is UIStackView }) as? UIStackView else {
             return
         }
-        
+
         let hasVisibleButton = toolStack.arrangedSubviews.contains { !$0.isHidden }
         toolGroup.isHidden = !hasVisibleButton
     }
+    #endif
 }
 
+#if compiler(>=6.2)
 // MARK: - Liquid Glass (iOS 26+)
 @available(iOS 26.0, *)
 extension CropToolbar {
@@ -670,14 +693,14 @@ extension CropToolbar {
         let margins = isPortrait
             ? UIEdgeInsets(top: 0, left: 20, bottom: 0, right: 20)
             : UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
-        
+
         glassStackView?.axis = axis
         glassStackView?.layoutMargins = margins
-        
+
         // Swap dimension constraints for the tool group capsule
         toolGroupHeightConstraint?.isActive = isPortrait
         toolGroupWidthConstraint?.isActive = !isPortrait
-        
+
         // Update tool group stack axis and capsule padding direction
         if let toolGroup = toolGroupContainerView,
            let toolStack = toolGroup.contentView.subviews.first(where: { $0 is UIStackView }) as? UIStackView {
@@ -689,3 +712,4 @@ extension CropToolbar {
         }
     }
 }
+#endif

--- a/Sources/Mantis/CropViewController/CropViewController+Layout.swift
+++ b/Sources/Mantis/CropViewController/CropViewController+Layout.swift
@@ -30,11 +30,13 @@ extension CropViewController {
         stackView?.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor).isActive = true
         stackView?.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor).isActive = true
         
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *), config.showAttachedCropToolbar {
             // Allow the crop view's mask to extend visually behind the toolbar
             cropView.clipsToBounds = false
             cropStackView?.clipsToBounds = false
         }
+        #endif
     }
     
     func setStackViewAxis() {
@@ -64,10 +66,12 @@ extension CropViewController {
             stackView?.addArrangedSubview(cropStackView)
         }
         
+        #if compiler(>=6.2)
         if #available(iOS 26.0, *), config.showAttachedCropToolbar {
             // Ensure the toolbar renders above the crop view's mask overflow
             stackView?.bringSubviewToFront(cropToolbar)
         }
+        #endif
     }
             
     func updateLayout() {


### PR DESCRIPTION
## Problem

v2.31.0 introduced Liquid Glass support in `CropToolbar.swift` using `UIGlassEffect` and `UIVisualEffectView.cornerConfiguration = .capsule()`. These APIs only exist in the iOS 26 SDK (Xcode 26 / Swift 6.2).

While the code correctly uses `@available(iOS 26.0, *)` for runtime gating, `@available` does **not** prevent compilation — the compiler still tries to resolve the types and fails on Xcode 16 where they don't exist:

```
Cannot find 'UIGlassEffect' in scope
Cannot infer contextual base in reference to member 'capsule'
Cannot infer contextual base in reference to member 'defaultHigh'
```

## Fix

Wrap all iOS 26 Liquid Glass code with `#if compiler(>=6.2)` so the code compiles cleanly on both Xcode 16 and Xcode 26.

This is the same approach already used in v2.28.2 for other iOS 26 APIs (see #493).

## Files changed

- `CropToolbar.swift` — guard properties, call sites, helper methods, and the `@available(iOS 26.0, *)` extension
- `CropViewController+Layout.swift` — guard two `#available(iOS 26.0, *)` blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal compatibility infrastructure to support future iOS versions and new device features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->