### PR TITLE
Add optional face validation on crop

### DIFF
--- a/Sources/Mantis/Config.swift
+++ b/Sources/Mantis/Config.swift
@@ -22,7 +22,21 @@
 //  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
 //  IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+import CoreImage
 import UIKit
+
+// MARK: - Face Validation
+public struct FaceValidationConfig {
+    /// When enabled, the cropped image is checked for faces before
+    /// calling the crop-success delegate. If no face is found,
+    /// `cropViewControllerDidFailFaceValidation(_:cropped:)` is called instead.
+    public var enabled: Bool = false
+
+    /// The accuracy used by `CIDetector`. Defaults to `CIDetectorAccuracyHigh`.
+    public var detectorAccuracy: String = CIDetectorAccuracyHigh
+
+    public init() {}
+}
 
 // MARK: - Localization
 public final class LocalizationConfig {
@@ -73,6 +87,8 @@ public struct Config {
         return Bundle(url: url)
     }()
     
+    public var faceValidationConfig = FaceValidationConfig()
+
     public var enableUndoRedo: Bool = false
     
     static var language: Language?

--- a/Sources/Mantis/Config.swift
+++ b/Sources/Mantis/Config.swift
@@ -27,13 +27,25 @@ import UIKit
 
 // MARK: - Face Validation
 public struct FaceValidationConfig {
+    public enum DetectorAccuracy {
+        case low
+        case high
+
+        var ciAccuracy: String {
+            switch self {
+            case .low: return CIDetectorAccuracyLow
+            case .high: return CIDetectorAccuracyHigh
+            }
+        }
+    }
+
     /// When enabled, the cropped image is checked for faces before
     /// calling the crop-success delegate. If no face is found,
     /// `cropViewControllerDidFailFaceValidation(_:cropped:)` is called instead.
     public var enabled: Bool = false
 
-    /// The accuracy used by `CIDetector`. Defaults to `CIDetectorAccuracyHigh`.
-    public var detectorAccuracy: String = CIDetectorAccuracyHigh
+    /// The accuracy used by `CIDetector`. Defaults to `.high`.
+    public var detectorAccuracy: DetectorAccuracy = .high
 
     public init() {}
 }

--- a/Sources/Mantis/CropViewController/CropViewController+CropAPI.swift
+++ b/Sources/Mantis/CropViewController/CropViewController+CropAPI.swift
@@ -5,6 +5,7 @@
 //  Extracted from CropViewController.swift
 //
 
+import CoreImage
 import UIKit
 
 // MARK: - Public Crop API
@@ -18,18 +19,17 @@ extension CropViewController {
             }
             return
         }
-        
+
         let transformation = cropView.makeTransformation()
-        
+
         Task { @MainActor [weak self] in
             guard let self = self else { return }
-            delegate?.cropViewControllerDidCrop(self,
-                                                cropped: image,
-                                                transformation: transformation,
-                                                cropInfo: cropInfo)
+            self.deliverCropResult(image: image,
+                                   transformation: transformation,
+                                   cropInfo: cropInfo)
         }
     }
-        
+
     public func crop() {
         switch config.cropMode {
         case .sync:
@@ -38,29 +38,71 @@ extension CropViewController {
         case .async:
             cropView.asyncCrop(completion: handleCropOutput)
         }
-        
+
         func handleCropOutput(_ cropOutput: CropOutput) {
             guard let image = cropOutput.croppedImage else {
                 delegate?.cropViewControllerDidFailToCrop(self, original: cropView.image)
                 return
             }
-            
-            delegate?.cropViewControllerDidCrop(self,
-                                                cropped: image,
-                                                transformation: cropOutput.transformation,
-                                                cropInfo: cropOutput.cropInfo)
+
+            deliverCropResult(image: image,
+                              transformation: cropOutput.transformation,
+                              cropInfo: cropOutput.cropInfo)
         }
     }
-    
+
     public func process(_ image: UIImage) -> UIImage? {
         return cropView.crop(image).croppedImage
     }
-    
+
     public func getExpectedCropImageSize() -> CGSize {
         cropView.getExpectedCropImageSize()
     }
-    
+
     public func update(_ image: UIImage) {
         cropView.update(image)
+    }
+}
+
+// MARK: - Face Validation
+extension CropViewController {
+    func deliverCropResult(image: UIImage, transformation: Transformation, cropInfo: CropInfo) {
+        guard config.faceValidationConfig.enabled else {
+            delegate?.cropViewControllerDidCrop(self,
+                                                cropped: image,
+                                                transformation: transformation,
+                                                cropInfo: cropInfo)
+            return
+        }
+
+        let accuracy = config.faceValidationConfig.detectorAccuracy
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let hasFace = Self.detectFace(in: image, accuracy: accuracy)
+            DispatchQueue.main.async {
+                guard let self = self else { return }
+                if hasFace {
+                    self.delegate?.cropViewControllerDidCrop(self,
+                                                             cropped: image,
+                                                             transformation: transformation,
+                                                             cropInfo: cropInfo)
+                } else {
+                    self.delegate?.cropViewControllerDidFailFaceValidation(self, cropped: image)
+                }
+            }
+        }
+    }
+
+    private static func detectFace(in image: UIImage, accuracy: String) -> Bool {
+        guard let ciImage = CIImage(image: image) else { return true }
+        guard let detector = CIDetector(
+            ofType: CIDetectorTypeFace,
+            context: nil,
+            options: [CIDetectorAccuracy: accuracy]
+        ) else {
+            return true
+        }
+        let features = detector.features(in: ciImage)
+        return !features.isEmpty
     }
 }

--- a/Sources/Mantis/CropViewController/CropViewController+CropAPI.swift
+++ b/Sources/Mantis/CropViewController/CropViewController+CropAPI.swift
@@ -75,7 +75,7 @@ extension CropViewController {
             return
         }
 
-        let accuracy = config.faceValidationConfig.detectorAccuracy
+        let accuracy = config.faceValidationConfig.detectorAccuracy.ciAccuracy
 
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
             let hasFace = Self.detectFace(in: image, accuracy: accuracy)
@@ -102,7 +102,26 @@ extension CropViewController {
         ) else {
             return true
         }
-        let features = detector.features(in: ciImage)
+        let orientation = image.imageOrientation.exifOrientation
+        let features = detector.features(in: ciImage,
+                                         options: [CIDetectorImageOrientation: orientation])
         return !features.isEmpty
+    }
+}
+
+// MARK: - EXIF Orientation
+private extension UIImage.Orientation {
+    var exifOrientation: Int {
+        switch self {
+        case .up: return 1
+        case .upMirrored: return 2
+        case .down: return 3
+        case .downMirrored: return 4
+        case .leftMirrored: return 5
+        case .right: return 6
+        case .rightMirrored: return 7
+        case .left: return 8
+        @unknown default: return 1
+        }
     }
 }

--- a/Sources/Mantis/Protocols/CropViewControllerDelegate.swift
+++ b/Sources/Mantis/Protocols/CropViewControllerDelegate.swift
@@ -14,7 +14,9 @@ public protocol CropViewControllerDelegate: AnyObject {
                                    cropInfo: CropInfo)
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage)
     func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage)
-    
+
+    func cropViewControllerDidFailFaceValidation(_ cropViewController: CropViewController, cropped: UIImage)
+
     func cropViewControllerDidBeginResize(_ cropViewController: CropViewController)
     func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo)
     
@@ -34,7 +36,9 @@ public protocol CropViewControllerDelegate: AnyObject {
 
 public extension CropViewControllerDelegate {
     func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {}
-    
+
+    func cropViewControllerDidFailFaceValidation(_ cropViewController: CropViewController, cropped: UIImage) {}
+
     func cropViewControllerDidBeginResize(_ cropViewController: CropViewController) {}
     
     func cropViewControllerDidEndResize(_ cropViewController: CropViewController, original: UIImage, cropInfo: CropInfo) {}

--- a/Tests/MantisTests/CropViewControllerTests.swift
+++ b/Tests/MantisTests/CropViewControllerTests.swift
@@ -102,14 +102,13 @@ final class CropViewControllerTests: XCTestCase {
         }
         let transformation = fakeCropView.makeTransformation()
         let cropInfo = fakeCropView.makeCropInfo()
+        let expectation = expectation(description: "Face validation completes")
+        fakeCropVCDelegate.onFaceValidationFailure = {
+            expectation.fulfill()
+        }
         cropVC.deliverCropResult(image: image,
                                  transformation: transformation,
                                  cropInfo: cropInfo)
-
-        let expectation = expectation(description: "Face validation completes")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            expectation.fulfill()
-        }
         waitForExpectations(timeout: 3.0)
 
         XCTAssertTrue(fakeCropVCDelegate.didFailFaceValidation)

--- a/Tests/MantisTests/CropViewControllerTests.swift
+++ b/Tests/MantisTests/CropViewControllerTests.swift
@@ -69,9 +69,50 @@ final class CropViewControllerTests: XCTestCase {
     
     func testCropViewDidEndCrop() {
         XCTAssertFalse(fakeCropVCDelegate.didEndCrop)
-        
+
         cropVC.cropViewDidEndCrop(cropVC.cropView)
-        
+
         XCTAssertTrue(fakeCropVCDelegate.didEndCrop)
+    }
+
+    func testDeliverCropResultWithFaceValidationDisabled() {
+        cropVC.config.faceValidationConfig.enabled = false
+        XCTAssertFalse(fakeCropVCDelegate.didCrop)
+
+        let image = UIImage()
+        let transformation = fakeCropView.makeTransformation()
+        let cropInfo = fakeCropView.makeCropInfo()
+        cropVC.deliverCropResult(image: image,
+                                 transformation: transformation,
+                                 cropInfo: cropInfo)
+
+        XCTAssertTrue(fakeCropVCDelegate.didCrop)
+        XCTAssertFalse(fakeCropVCDelegate.didFailFaceValidation)
+    }
+
+    func testDeliverCropResultWithFaceValidationEnabled() {
+        cropVC.config.faceValidationConfig.enabled = true
+        XCTAssertFalse(fakeCropVCDelegate.didFailFaceValidation)
+
+        // Create a solid-color image (no face) that CIImage can process
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10))
+        let image = renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 10, height: 10))
+        }
+        let transformation = fakeCropView.makeTransformation()
+        let cropInfo = fakeCropView.makeCropInfo()
+        cropVC.deliverCropResult(image: image,
+                                 transformation: transformation,
+                                 cropInfo: cropInfo)
+
+        let expectation = expectation(description: "Face validation completes")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 3.0)
+
+        XCTAssertTrue(fakeCropVCDelegate.didFailFaceValidation)
+        XCTAssertFalse(fakeCropVCDelegate.didCrop)
     }
 }

--- a/Tests/MantisTests/Mock/FakeCropViewControllerDelegate.swift
+++ b/Tests/MantisTests/Mock/FakeCropViewControllerDelegate.swift
@@ -51,7 +51,10 @@ class FakeCropViewControllerDelegate: CropViewControllerDelegate {
         didImageTransformed = true
     }
 
+    var onFaceValidationFailure: (() -> Void)?
+
     func cropViewControllerDidFailFaceValidation(_ cropViewController: CropViewController, cropped: UIImage) {
         didFailFaceValidation = true
+        onFaceValidationFailure?()
     }
 }

--- a/Tests/MantisTests/Mock/FakeCropViewControllerDelegate.swift
+++ b/Tests/MantisTests/Mock/FakeCropViewControllerDelegate.swift
@@ -17,7 +17,8 @@ class FakeCropViewControllerDelegate: CropViewControllerDelegate {
     var didBeginCrop = false
     var didEndCrop = false
     var didImageTransformed = false
-    
+    var didFailFaceValidation = false
+
     func cropViewControllerDidCrop(_ cropViewController: CropViewController, cropped: UIImage, transformation: Transformation, cropInfo: CropInfo) {
         didCrop = true
     }
@@ -48,5 +49,9 @@ class FakeCropViewControllerDelegate: CropViewControllerDelegate {
     
     func cropViewControllerDidImageTransformed(_ cropViewController: CropViewController, transformation: Transformation) {
         didImageTransformed = true
+    }
+
+    func cropViewControllerDidFailFaceValidation(_ cropViewController: CropViewController, cropped: UIImage) {
+        didFailFaceValidation = true
     }
 }


### PR DESCRIPTION
## Summary

Adds an opt-in face validation step to the crop flow using `CIDetector`. When enabled via `Config.faceValidationConfig.enabled`, the cropped image is checked for faces before delivering the result. If no face is found, a new delegate method `cropViewControllerDidFailFaceValidation(_:cropped:)` is called instead of the crop-success delegate — allowing the consumer to show an error while keeping the user on the crop screen.

- New `FaceValidationConfig` struct on `Config` (`enabled: Bool`, `detectorAccuracy: String`)
- New optional `CropViewControllerDelegate` method with default empty implementation (non-breaking)
- Detection runs on a background thread; gracefully falls back to allowing the crop if `CIDetector` fails

### Usage

```swift
var config = Mantis.Config()
config.faceValidationConfig.enabled = true

let cropVC = Mantis.cropViewController(image: image, config: config)
cropVC.delegate = self

// Delegate
func cropViewControllerDidFailFaceValidation(_ vc: CropViewController, cropped: UIImage) {
    // Show alert — user stays on the crop screen to retry
}
```

### Use case

Profile photo uploads that require a visible face in the cropped result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional face validation for cropped images with configurable accuracy; crops are delivered only when validation passes.
  * New callback to notify when a crop fails face validation (no-op by default).
* **Bug Fixes / Behavior**
  * Crop delivery consistently routes through the validation flow to ensure correct success/failure callbacks.
* **Tests**
  * Added tests and test helpers covering both enabled and disabled face-validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->