### PR TITLE
fix: guard against NaN/Infinite values to prevent crashes during crop and rotation

### DIFF
--- a/Sources/Mantis/CropView/CropView+Layout.swift
+++ b/Sources/Mantis/CropView/CropView+Layout.swift
@@ -220,6 +220,10 @@ extension CropView {
         let width = abs(cos(radians)) * cropAuxiliaryIndicatorView.frame.width + abs(sin(radians)) * cropAuxiliaryIndicatorView.frame.height
         let height = abs(sin(radians)) * cropAuxiliaryIndicatorView.frame.width + abs(cos(radians)) * cropAuxiliaryIndicatorView.frame.height
         
+        guard width.isFinite, height.isFinite, width > 0, height > 0 else {
+            return
+        }
+        
         cropWorkbenchView.updateLayout(byNewSize: CGSize(width: width, height: height))
         
         if !isManuallyZoomed || cropWorkbenchView.shouldScale() {
@@ -233,9 +237,13 @@ extension CropView {
     }
     
     func updatePositionFor90Rotation(by radians: CGFloat) {
-        func adjustScrollViewForNormalRatio(by radians: CGFloat) -> CGFloat {
+        func adjustScrollViewForNormalRatio(by radians: CGFloat) -> CGFloat? {
             let width = abs(cos(radians)) * cropAuxiliaryIndicatorView.frame.width + abs(sin(radians)) * cropAuxiliaryIndicatorView.frame.height
             let height = abs(sin(radians)) * cropAuxiliaryIndicatorView.frame.width + abs(cos(radians)) * cropAuxiliaryIndicatorView.frame.height
+            
+            guard width.isFinite, height.isFinite, width > 0, height > 0 else {
+                return nil
+            }
             
             let newSize: CGSize
             if viewModel.rotationType.isRotatedByMultiple180 {
@@ -244,12 +252,16 @@ extension CropView {
                 newSize = CGSize(width: height, height: width)
             }
             
+            guard cropWorkbenchView.bounds.width > 0 else { return nil }
             let scale = newSize.width / cropWorkbenchView.bounds.width
+            guard scale.isFinite, scale > 0 else { return nil }
             cropWorkbenchView.updateLayout(byNewSize: newSize)
             return scale
         }
         
-        let scale = adjustScrollViewForNormalRatio(by: radians)
+        guard let scale = adjustScrollViewForNormalRatio(by: radians) else {
+            return
+        }
         
         let newZoomScale = cropWorkbenchView.zoomScale * scale
         cropWorkbenchView.minimumZoomScale = newZoomScale

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -160,6 +160,12 @@ final class CropView: UIView {
     }
     
     private func handleCropBoxFrameChange(_ cropBoxFrame: CGRect) {
+        guard cropBoxFrame.width.isFinite, cropBoxFrame.height.isFinite,
+              cropBoxFrame.origin.x.isFinite, cropBoxFrame.origin.y.isFinite,
+              cropBoxFrame.width >= 0, cropBoxFrame.height >= 0 else {
+            return
+        }
+        
         cropAuxiliaryIndicatorView.frame = cropBoxFrame
         
         var cropRatio: CGFloat = 1.0

--- a/Sources/Mantis/CropView/CropViewModel.swift
+++ b/Sources/Mantis/CropView/CropViewModel.swift
@@ -59,16 +59,19 @@ final class CropViewModel: CropViewModelProtocol {
     
     var cropBoxFrameChanged: (_ frame: CGRect) -> Void = { _ in }
     
-    var cropBoxFrame = CGRect.zero {
-        didSet {
-            guard cropBoxFrame.origin.x.isFinite, cropBoxFrame.origin.y.isFinite,
-                  cropBoxFrame.width.isFinite, cropBoxFrame.height.isFinite,
-                  cropBoxFrame.width >= 0, cropBoxFrame.height >= 0 else {
-                cropBoxFrame = oldValue
+    private var _cropBoxFrame = CGRect.zero
+    var cropBoxFrame: CGRect {
+        get { _cropBoxFrame }
+        set {
+            guard newValue.origin.x.isFinite, newValue.origin.y.isFinite,
+                  newValue.size.width.isFinite, newValue.size.height.isFinite,
+                  newValue.size.width >= 0, newValue.size.height >= 0 else {
                 return
             }
-            if oldValue != cropBoxFrame {
-                cropBoxFrameChanged(cropBoxFrame)
+            let oldValue = _cropBoxFrame
+            _cropBoxFrame = newValue
+            if oldValue != newValue {
+                cropBoxFrameChanged(newValue)
             }
         }
     }

--- a/Sources/Mantis/CropView/CropViewModel.swift
+++ b/Sources/Mantis/CropView/CropViewModel.swift
@@ -61,6 +61,11 @@ final class CropViewModel: CropViewModelProtocol {
     
     var cropBoxFrame = CGRect.zero {
         didSet {
+            guard cropBoxFrame.origin.x.isFinite, cropBoxFrame.origin.y.isFinite,
+                  cropBoxFrame.width.isFinite, cropBoxFrame.height.isFinite else {
+                cropBoxFrame = oldValue
+                return
+            }
             if oldValue != cropBoxFrame {
                 cropBoxFrameChanged(cropBoxFrame)
             }

--- a/Sources/Mantis/CropView/CropViewModel.swift
+++ b/Sources/Mantis/CropView/CropViewModel.swift
@@ -62,7 +62,8 @@ final class CropViewModel: CropViewModelProtocol {
     var cropBoxFrame = CGRect.zero {
         didSet {
             guard cropBoxFrame.origin.x.isFinite, cropBoxFrame.origin.y.isFinite,
-                  cropBoxFrame.width.isFinite, cropBoxFrame.height.isFinite else {
+                  cropBoxFrame.width.isFinite, cropBoxFrame.height.isFinite,
+                  cropBoxFrame.width >= 0, cropBoxFrame.height >= 0 else {
                 cropBoxFrame = oldValue
                 return
             }

--- a/Sources/Mantis/CropView/CropWorkbenchView.swift
+++ b/Sources/Mantis/CropView/CropWorkbenchView.swift
@@ -79,10 +79,20 @@ final class CropWorkbenchView: UIScrollView {
             return 1.0
         }
         
+        guard imageContainer.bounds.width > 0, imageContainer.bounds.height > 0,
+              bounds.width > 0, bounds.height > 0 else {
+            return max(1.0, initialMinimumZoomScale)
+        }
+        
         let scaleW = bounds.width / imageContainer.bounds.width
         let scaleH = bounds.height / imageContainer.bounds.height
+        let result = max(scaleW, scaleH) * initialMinimumZoomScale
         
-        return max(scaleW, scaleH) * initialMinimumZoomScale
+        guard result.isFinite, result > 0 else {
+            return max(1.0, initialMinimumZoomScale)
+        }
+        
+        return result
     }
 }
 

--- a/Sources/Mantis/Extensions/CGImageExtensions.swift
+++ b/Sources/Mantis/Extensions/CGImageExtensions.swift
@@ -26,7 +26,9 @@ extension CGImage {
         guard outputSize.width > 0, outputSize.height > 0,
               outputSize.width.isFinite, outputSize.height.isFinite,
               cropSize.width > 0, cropSize.height > 0,
-              imageViewSize.width > 0, imageViewSize.height > 0 else {
+              cropSize.width.isFinite, cropSize.height.isFinite,
+              imageViewSize.width > 0, imageViewSize.height > 0,
+              imageViewSize.width.isFinite, imageViewSize.height.isFinite else {
             return nil
         }
         

--- a/Sources/Mantis/Extensions/CGImageExtensions.swift
+++ b/Sources/Mantis/Extensions/CGImageExtensions.swift
@@ -23,6 +23,13 @@ extension CGImage {
                           outputSize: CGSize,
                           cropSize: CGSize,
                           imageViewSize: CGSize) throws -> CGImage? {
+        guard outputSize.width > 0, outputSize.height > 0,
+              outputSize.width.isFinite, outputSize.height.isFinite,
+              cropSize.width > 0, cropSize.height > 0,
+              imageViewSize.width > 0, imageViewSize.height > 0 else {
+            return nil
+        }
+        
         guard var colorSpaceRef = self.colorSpace else {
             throw ImageProcessError.noColorSpace
         }

--- a/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
+++ b/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
@@ -30,8 +30,9 @@ typealias RadiansAngle = CGFloat
 extension FloatingPoint {
     var isBad: Bool { return isNaN || isInfinite }
     var checked: Self {
-        guard !isBad && !isInfinite else {
-            fatalError("bad number!")
+        guard !isBad else {
+            assertionFailure("bad number!")
+            return 0
         }
         return self
     }
@@ -41,28 +42,37 @@ extension CGSize {
     var hasNaN: Bool {return width.isBad || height.isBad }
     var checked: CGSize {
         guard !hasNaN else {
-            fatalError("bad number!")
+            assertionFailure("bad number!")
+            return .zero
         }
         return self
     }
 }
 
 extension CGRect {
-    var center: CGPoint { return CGPoint(x: midX, y: midY).checked }
+    var center: CGPoint {
+        guard !hasNaN else { return .zero }
+        return CGPoint(x: midX, y: midY)
+    }
     var hasNaN: Bool {return size.hasNaN || origin.hasNaN}
     var checked: CGRect {
         guard !hasNaN else {
-            fatalError("bad number!")
+            assertionFailure("bad number!")
+            return .zero
         }
         return self
     }
 }
 
 extension CGPoint {
-    var vector: CGVector { return CGVector(dx: x, dy: y).checked }
+    var vector: CGVector {
+        guard !hasNaN else { return .zero }
+        return CGVector(dx: x, dy: y)
+    }
     var checked: CGPoint {
         guard !hasNaN else {
-            fatalError("bad number!")
+            assertionFailure("bad number!")
+            return .zero
         }
         return self
     }
@@ -73,7 +83,8 @@ extension CGVector {
     var hasNaN: Bool { return dx.isBad || dy.isBad }
     var checked: CGVector {
         guard !hasNaN else {
-            fatalError("bad number!")
+            assertionFailure("bad number!")
+            return .zero
         }
         return self
     }
@@ -90,13 +101,15 @@ extension CGVector {
     func scale(_ scale: CGFloat) -> CGVector { return CGVector(dx: dx * scale, dy: dy * scale).checked}
     
     init(fromPoint: CGPoint, toPoint: CGPoint) {
-        guard !fromPoint.hasNaN && !toPoint.hasNaN  else {
-            fatalError("Nan point!")
-        }
         self.init()
+        guard !fromPoint.hasNaN && !toPoint.hasNaN else {
+            assertionFailure("NaN point!")
+            dx = 0
+            dy = 0
+            return
+        }
         dx = toPoint.x - fromPoint.x
         dy = toPoint.y - fromPoint.y
-        _ = self.checked
     }
     
     init(angle: RadiansAngle) {

--- a/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
+++ b/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
@@ -114,8 +114,8 @@ extension CGVector {
             dy = 0
             return
         }
-        dx = toPoint.x - fromPoint.x
-        dy = toPoint.y - fromPoint.y
+        dx = (toPoint.x - fromPoint.x).checked
+        dy = (toPoint.y - fromPoint.y).checked
     }
     
     init(angle: RadiansAngle) {

--- a/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
+++ b/Sources/Mantis/Extensions/CoreGraphicsExtensions.swift
@@ -51,7 +51,10 @@ extension CGSize {
 
 extension CGRect {
     var center: CGPoint {
-        guard !hasNaN else { return .zero }
+        guard !hasNaN else {
+            assertionFailure("bad number!")
+            return .zero
+        }
         return CGPoint(x: midX, y: midY)
     }
     var hasNaN: Bool {return size.hasNaN || origin.hasNaN}
@@ -66,7 +69,10 @@ extension CGRect {
 
 extension CGPoint {
     var vector: CGVector {
-        guard !hasNaN else { return .zero }
+        guard !hasNaN else {
+            assertionFailure("bad number!")
+            return .zero
+        }
         return CGVector(dx: x, dy: y)
     }
     var checked: CGPoint {

--- a/Sources/Mantis/Extensions/UIImageExtensions.swift
+++ b/Sources/Mantis/Extensions/UIImageExtensions.swift
@@ -160,6 +160,7 @@ extension UIImage {
         let sublayerTransform = cropInfo.skewSublayerTransform
 
         guard imgContainerFrame.size.width > 0, imgContainerFrame.size.height > 0,
+              imgContainerFrame.size.width.isFinite, imgContainerFrame.size.height.isFinite,
               imgContainerFrame.origin.x.isFinite, imgContainerFrame.origin.y.isFinite else { return nil }
 
         // sublayerTransform anchor in content coordinates

--- a/Sources/Mantis/Extensions/UIImageExtensions.swift
+++ b/Sources/Mantis/Extensions/UIImageExtensions.swift
@@ -146,9 +146,13 @@ extension UIImage {
         let zoomScaleX = abs(cropInfo.scaleX)
         let zoomScaleY = abs(cropInfo.scaleY)
 
+        guard imageViewSize.width > 0, imageViewSize.height > 0,
+              zoomScaleX > 0, zoomScaleY > 0 else { return nil }
+
         let outputWidth = round((size.width / imageViewSize.width * cropSize.width) / zoomScaleX)
         let outputHeight = round((size.height / imageViewSize.height * cropSize.height) / zoomScaleY)
-        guard outputWidth > 0 && outputHeight > 0 else { return nil }
+        guard outputWidth > 0 && outputHeight > 0,
+              outputWidth.isFinite && outputHeight.isFinite else { return nil }
 
         let scrollBoundsSize = cropInfo.scrollBoundsSize
         let scrollContentOffset = cropInfo.scrollContentOffset
@@ -223,11 +227,15 @@ extension UIImage {
         filter.setValue(CIVector(x: pts[2].x, y: pts[2].y), forKey: "inputBottomRight")
         filter.setValue(CIVector(x: pts[3].x, y: pts[3].y), forKey: "inputBottomLeft")
 
-        guard let correctedOutput = filter.outputImage else { return nil }
+        guard let correctedOutput = filter.outputImage,
+              correctedOutput.extent.width > 0,
+              correctedOutput.extent.height > 0 else { return nil }
 
         // Render at desired output size
         let renderScaleX = outputWidth / correctedOutput.extent.width
         let renderScaleY = outputHeight / correctedOutput.extent.height
+        guard renderScaleX.isFinite, renderScaleY.isFinite,
+              renderScaleX > 0, renderScaleY > 0 else { return nil }
         let scaledImage = correctedOutput.transformed(by: CGAffineTransform(scaleX: renderScaleX, y: renderScaleY))
 
         let context = CIContext(options: [.useSoftwareRenderer: false])
@@ -282,8 +290,18 @@ extension UIImage {
         let cropSize = cropInfo.cropSize
         let imageViewSize = cropInfo.imageViewSize
         
+        guard imageViewSize.width > 0, imageViewSize.height > 0,
+              zoomScaleX > 0, zoomScaleY > 0 else {
+            return .zero
+        }
+        
         let expectedWidth = round((size.width / imageViewSize.width * cropSize.width) / zoomScaleX)
         let expectedHeight = round((size.height / imageViewSize.height * cropSize.height) / zoomScaleY)
+        
+        guard expectedWidth.isFinite, expectedHeight.isFinite,
+              expectedWidth > 0, expectedHeight > 0 else {
+            return .zero
+        }
         
         return CGSize(width: expectedWidth, height: expectedHeight)
     }

--- a/Sources/Mantis/Extensions/UIImageExtensions.swift
+++ b/Sources/Mantis/Extensions/UIImageExtensions.swift
@@ -159,6 +159,9 @@ extension UIImage {
         let imgContainerFrame = cropInfo.imageContainerFrame
         let sublayerTransform = cropInfo.skewSublayerTransform
 
+        guard imgContainerFrame.size.width > 0, imgContainerFrame.size.height > 0,
+              imgContainerFrame.origin.x.isFinite, imgContainerFrame.origin.y.isFinite else { return nil }
+
         // sublayerTransform anchor in content coordinates
         let anchorX = scrollContentOffset.x + scrollBoundsSize.width / 2
         let anchorY = scrollContentOffset.y + scrollBoundsSize.height / 2

--- a/Tests/MantisTests/CropViewModelTests.swift
+++ b/Tests/MantisTests/CropViewModelTests.swift
@@ -241,4 +241,33 @@ final class CropViewModelTests: XCTestCase {
         viewModel.setBetweenOperationStatus()
         XCTAssertEqual(viewModel.viewStatus, .betweenOperation)
     }
+    
+    func testCropBoxFrameRejectsNaN() {
+        let validFrame = CGRect(x: 10, y: 10, width: 100, height: 100)
+        viewModel.cropBoxFrame = validFrame
+        
+        var callbackCount = 0
+        viewModel.cropBoxFrameChanged = { _ in callbackCount += 1 }
+        
+        // NaN origin should be rejected
+        viewModel.cropBoxFrame = CGRect(x: CGFloat.nan, y: 10, width: 100, height: 100)
+        XCTAssertEqual(viewModel.cropBoxFrame, validFrame)
+        
+        // Infinite width should be rejected
+        viewModel.cropBoxFrame = CGRect(x: 10, y: 10, width: CGFloat.infinity, height: 100)
+        XCTAssertEqual(viewModel.cropBoxFrame, validFrame)
+        
+        // Negative size should be rejected
+        viewModel.cropBoxFrame = CGRect(x: 10, y: 10, width: -5, height: 100)
+        XCTAssertEqual(viewModel.cropBoxFrame, validFrame)
+        
+        // None of the invalid assignments should have triggered the callback
+        XCTAssertEqual(callbackCount, 0)
+        
+        // A valid assignment should still work
+        let newFrame = CGRect(x: 20, y: 20, width: 200, height: 200)
+        viewModel.cropBoxFrame = newFrame
+        XCTAssertEqual(viewModel.cropBoxFrame, newFrame)
+        XCTAssertEqual(callbackCount, 1)
+    }
 }


### PR DESCRIPTION
Add defensive checks throughout the crop pipeline to prevent two categories of crashes reported on iOS/iPadOS 26.0+:

1. "Double value cannot be converted to Int because it is either infinite or NaN" in CGImageExtensions.swift when outputSize contains NaN/Inf from division by zero imageViewSize or zoomScale.

2. CALayerInvalidGeometry when setting cropAuxiliaryIndicatorView.frame with NaN values during 90° rotation animation.

Key changes:
- Validate outputSize, cropSize, imageViewSize before CGContext creation
- Guard getOutputCropImageSize and cropWithPerspective against zero divisors
- Reject NaN cropBoxFrame in CropViewModel setter to stop propagation
- Guard handleCropBoxFrameChange against invalid frame geometry
- Protect adjustWorkbenchView and updatePositionFor90Rotation from NaN sizes
- Guard getBoundZoomScale against zero-size bounds/container
- Replace fatalError with assertionFailure in CoreGraphicsExtensions so NaN values degrade gracefully in production instead of crashing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added defensive validation across cropping, layout, and image-transformation flows to reject non-finite or non-positive geometry.
  * Prevented applying invalid state (zoom, offsets, masks, layout) and replaced hard crashes with safe fallbacks/assertions for improved stability during edge-case geometry and rotations.
  * Image transformation and perspective-crop now fail fast when inputs or computed sizes are invalid.
* **Tests**
  * Added a unit test ensuring invalid crop-frame values are rejected and do not trigger change callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->