### PR TITLE
fix: avoid contentOffset snap on first skew frame after rotation/resize

### DIFF
--- a/Example/DemoViewController.swift
+++ b/Example/DemoViewController.swift
@@ -62,10 +62,7 @@ class DemoViewController: UIViewController {
         "Custom Toolbar (Buttons)",
         "Clockwise rotation with slide dial",
         "Crop Shapes",
-        "Hide Rotation Dial",
-        "Dark Background",
-        "Light Background",
-        "Color Background"
+        "Hide Rotation Dial"
     ]
     
     // MARK: - Lifecycle
@@ -351,28 +348,6 @@ class DemoViewController: UIViewController {
         present(navigationController, animated: true)
     }
     
-    @objc private func darkBackgroundAction() {
-        presentWith(backgroundEffect: .dark)
-    }
-    
-    @objc private func lightBackgroundAction() {
-        presentWith(backgroundEffect: .light)
-    }
-    
-    @objc private func colorBackgroundAction() {
-        guard let image = image else {
-            return
-        }
-        
-        var config = Mantis.Config()
-        config.cropViewConfig.backgroundColor = .yellow
-        let cropViewController = Mantis.cropViewController(image: image,
-                                                           config: config)
-        cropViewController.modalPresentationStyle = .fullScreen
-        cropViewController.delegate = self
-        present(cropViewController, animated: true)
-    }
-    
     // MARK: - Helper Methods
     
     typealias CropShapeItem = (type: Mantis.CropShapeType, title: String)
@@ -432,20 +407,6 @@ class DemoViewController: UIViewController {
         present(actionSheet, animated: true)
     }
     
-    private func presentWith(backgroundEffect effect: CropMaskVisualEffectType) {
-        guard let image = image else {
-            return
-        }
-        
-        var config = Mantis.Config()
-        config.cropViewConfig.cropMaskVisualEffectType = effect
-        let cropViewController = Mantis.cropViewController(image: image,
-                                                           config: config)
-        cropViewController.modalPresentationStyle = .fullScreen
-        cropViewController.delegate = self
-        present(cropViewController, animated: true)
-    }
-    
     private func getActionForIndex(_ index: Int) -> Selector? {
         switch index {
         case 0: return #selector(normalAction)
@@ -459,9 +420,6 @@ class DemoViewController: UIViewController {
         case 8: return #selector(clockwiseRotationAction)
         case 9: return #selector(cropShapesAction)
         case 10: return #selector(hideRotationDialAction)
-        case 11: return #selector(darkBackgroundAction)
-        case 12: return #selector(lightBackgroundAction)
-        case 13: return #selector(colorBackgroundAction)
         default: return nil
         }
     }

--- a/Sources/Mantis/AppearanceColorPreset.swift
+++ b/Sources/Mantis/AppearanceColorPreset.swift
@@ -275,6 +275,19 @@ enum AppearanceColorPreset {
         }
     }
     
+    // MARK: - CropAuxiliaryIndicator (border + corner/edge handles)
+    static func auxiliaryIndicatorColor(for mode: AppearanceMode) -> UIColor {
+        let lightColor = UIColor(white: 0.3, alpha: 1.0)
+        switch mode {
+        case .forceDark:
+            return .white
+        case .forceLight:
+            return lightColor
+        case .system:
+            return dynamicColor(dark: .white, light: lightColor)
+        }
+    }
+
     // MARK: - Activity Indicator
     static func activityIndicatorColor(for mode: AppearanceMode) -> UIColor {
         switch mode {

--- a/Sources/Mantis/CropAuxiliaryIndicatorConfig.swift
+++ b/Sources/Mantis/CropAuxiliaryIndicatorConfig.swift
@@ -20,15 +20,19 @@ public struct CropAuxiliaryIndicatorConfig {
     public var disableCropBoxDeformation = false
     public var style: CropAuxiliaryIndicatorStyleType = .normal
     
-    public var borderNormalColor = UIColor.white
-    
-    /**
-        The color of the border when showing which border is touched currently.
-     */
-    public var borderHintColor = UIColor.white
-    
-    public var cornerHandleColor = UIColor.white
-    public var edgeLineHandleColor = UIColor.white
+    /// When `nil`, the value is resolved from the active `AppearanceMode` (or
+    /// falls back to white). Set explicitly to override the appearance preset.
+    public var borderNormalColor: UIColor?
+
+    /// The color of the border when showing which border is touched currently.
+    /// `nil` defers to the appearance preset; see `borderNormalColor`.
+    public var borderHintColor: UIColor?
+
+    /// `nil` defers to the appearance preset; see `borderNormalColor`.
+    public var cornerHandleColor: UIColor?
+
+    /// `nil` defers to the appearance preset; see `borderNormalColor`.
+    public var edgeLineHandleColor: UIColor?
     
     public var gridMainColor = UIColor.white
     

--- a/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
+++ b/Sources/Mantis/CropView/CropAuxiliaryIndicatorView.swift
@@ -60,10 +60,10 @@ final class CropAuxiliaryIndicatorView: UIView, CropAuxiliaryIndicatorViewProtoc
         disableCropBoxDeformation = config.disableCropBoxDeformation
         style = config.style
         
-        borderNormalColor = config.borderNormalColor
-        borderHintColor = config.borderHintColor
-        cornerHandleColor = config.cornerHandleColor
-        edgeLineHandleColor = config.edgeLineHandleColor
+        borderNormalColor = config.borderNormalColor ?? .white
+        borderHintColor = config.borderHintColor ?? .white
+        cornerHandleColor = config.cornerHandleColor ?? .white
+        edgeLineHandleColor = config.edgeLineHandleColor ?? .white
         gridMainColor = config.gridMainColor
         gridSecondaryColor = config.gridSecondaryColor
         

--- a/Sources/Mantis/CropView/CropView+Skew.swift
+++ b/Sources/Mantis/CropView/CropView+Skew.swift
@@ -654,9 +654,22 @@ extension CropView {
                 y: min(max(current.y, minY), maxY)
             )
         } else {
-            // First skew change from zero at default zoom: jump
-            // directly to optimal for strict edge-to-edge alignment.
-            cropWorkbenchView.contentOffset = optimalOffset
+            // First skew change from zero at default zoom: apply only the
+            // skew-related shift (optimalOffset relative to centerOffset)
+            // as a delta on the user's current contentOffset. When nothing
+            // has displaced the view from center, current == centerOffset
+            // and this still lands on optimalOffset (preserving edge-to-edge
+            // alignment). After a straighten rotation or a manual crop
+            // resize, current can differ from centerOffset; snapping to the
+            // absolute optimal would jump visibly, so apply the shift only.
+            let current = cropWorkbenchView.contentOffset
+            let center = context.centerOffset
+            let shiftX = optimalOffset.x - center.x
+            let shiftY = optimalOffset.y - center.y
+            cropWorkbenchView.contentOffset = CGPoint(
+                x: min(max(current.x + shiftX, minX), maxX),
+                y: min(max(current.y + shiftY, minY), maxY)
+            )
         }
         
         skewState.previousOptimalOffset = optimalOffset

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -111,6 +111,13 @@ private func applyAppearanceDefaults(to config: inout Mantis.Config) {
     // CropToolbarConfig
     config.cropToolbarConfig.backgroundColor = AppearanceColorPreset.toolbarBackground(for: mode)
     config.cropToolbarConfig.foregroundColor = AppearanceColorPreset.toolbarForeground(for: mode)
+
+    // CropAuxiliaryIndicatorConfig (border + corner/edge handles only; grid colors untouched)
+    let auxiliaryColor = AppearanceColorPreset.auxiliaryIndicatorColor(for: mode)
+    config.cropViewConfig.cropAuxiliaryIndicatorConfig.borderNormalColor = auxiliaryColor
+    config.cropViewConfig.cropAuxiliaryIndicatorConfig.borderHintColor = auxiliaryColor
+    config.cropViewConfig.cropAuxiliaryIndicatorConfig.cornerHandleColor = auxiliaryColor
+    config.cropViewConfig.cropAuxiliaryIndicatorConfig.edgeLineHandleColor = auxiliaryColor
     
     // CropMaskVisualEffectType (only if user hasn't set a custom backgroundColor)
     if config.cropViewConfig.backgroundColor == nil {

--- a/Sources/Mantis/Mantis.swift
+++ b/Sources/Mantis/Mantis.swift
@@ -112,12 +112,15 @@ private func applyAppearanceDefaults(to config: inout Mantis.Config) {
     config.cropToolbarConfig.backgroundColor = AppearanceColorPreset.toolbarBackground(for: mode)
     config.cropToolbarConfig.foregroundColor = AppearanceColorPreset.toolbarForeground(for: mode)
 
-    // CropAuxiliaryIndicatorConfig (border + corner/edge handles only; grid colors untouched)
+    // CropAuxiliaryIndicatorConfig (border + corner/edge handles only; grid colors untouched).
+    // Only fill in values the caller didn't set explicitly, so custom colors survive.
     let auxiliaryColor = AppearanceColorPreset.auxiliaryIndicatorColor(for: mode)
-    config.cropViewConfig.cropAuxiliaryIndicatorConfig.borderNormalColor = auxiliaryColor
-    config.cropViewConfig.cropAuxiliaryIndicatorConfig.borderHintColor = auxiliaryColor
-    config.cropViewConfig.cropAuxiliaryIndicatorConfig.cornerHandleColor = auxiliaryColor
-    config.cropViewConfig.cropAuxiliaryIndicatorConfig.edgeLineHandleColor = auxiliaryColor
+    var auxiliaryConfig = config.cropViewConfig.cropAuxiliaryIndicatorConfig
+    if auxiliaryConfig.borderNormalColor == nil { auxiliaryConfig.borderNormalColor = auxiliaryColor }
+    if auxiliaryConfig.borderHintColor == nil { auxiliaryConfig.borderHintColor = auxiliaryColor }
+    if auxiliaryConfig.cornerHandleColor == nil { auxiliaryConfig.cornerHandleColor = auxiliaryColor }
+    if auxiliaryConfig.edgeLineHandleColor == nil { auxiliaryConfig.edgeLineHandleColor = auxiliaryColor }
+    config.cropViewConfig.cropAuxiliaryIndicatorConfig = auxiliaryConfig
     
     // CropMaskVisualEffectType (only if user hasn't set a custom backgroundColor)
     if config.cropViewConfig.backgroundColor == nil {


### PR DESCRIPTION
When the user adjusted the crop size or straightened the image, the scroll view's contentOffset no longer matched centerOffset. The first skew frame then snapped contentOffset directly to optimalOffset, producing a visible jump. Apply the skew-related shift as a delta from centerOffset instead, so the user's current position is preserved while still landing on optimalOffset in the untouched case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve manual pan/scroll offsets when auto-aligning skewed content so existing panning is not lost.

* **New Features**
  * Added auxiliary indicator color choices (light / dark / system).
  * Appearance mode now applies to auxiliary UI elements (borders, handles, indicators) for consistent theming; element colors can now defer to appearance presets when unset.

* **Chores**
  * Removed several background-effect demo menu options to simplify the demo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->