### PR TITLE
fix: avoid double safe area inset offset in embedded mode (#487)

### DIFF
--- a/Sources/Mantis/CropViewController/CropViewController+Layout.swift
+++ b/Sources/Mantis/CropViewController/CropViewController+Layout.swift
@@ -25,10 +25,23 @@ extension CropViewController {
         stackView?.translatesAutoresizingMaskIntoConstraints = false
         cropToolbar.translatesAutoresizingMaskIntoConstraints = false
         
-        stackView?.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
-        stackView?.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        stackView?.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor).isActive = true
-        stackView?.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor).isActive = true
+        if config.cropToolbarConfig.mode == .embedded {
+            // In embedded mode the crop view is added as a subview of a container
+            // that already manages its own safe area. Pinning to the safe area
+            // layout guide here would apply the inherited insets a second time,
+            // pushing the content down and clipping the bottom (notably on iOS 26,
+            // which changed how safe area insets propagate to child views).
+            // Pin directly to view edges and let the embedding parent own safe area.
+            stackView?.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
+            stackView?.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+            stackView?.leftAnchor.constraint(equalTo: view.leftAnchor).isActive = true
+            stackView?.rightAnchor.constraint(equalTo: view.rightAnchor).isActive = true
+        } else {
+            stackView?.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+            stackView?.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+            stackView?.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor).isActive = true
+            stackView?.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor).isActive = true
+        }
         
         #if compiler(>=6.2)
         if #available(iOS 26.0, *), config.showAttachedCropToolbar {


### PR DESCRIPTION
## Summary

Fixes #487 — embedded `CropViewController` shows an incorrect (downward-shifted, bottom-clipped) layout on iOS 26.

When `config.cropToolbarConfig.mode == .embedded`, the crop view controller's view is added as a subview of a container that **already** manages its own safe area. In `initLayout()` the stack view was pinned to `view.safeAreaLayoutGuide`, which then applied the inherited safe area insets a *second* time — a double offset that pushes content down and clips the bottom.

This worked on iOS 18 but broke on iOS 26, which [changed how safe area insets propagate to child views](https://developer.apple.com/forums/thread/798014). It also matches the reporter's finding that `didSelectReset` (which recomputes bounds) "fixes" the layout.

## Change

In `CropViewController+Layout.swift`, when in embedded mode, pin the stack view directly to `view.topAnchor` / `bottomAnchor` / `leftAnchor` / `rightAnchor` and let the embedding parent own safe area management. Normal (modal / full-screen) presentation keeps the existing `safeAreaLayoutGuide` constraints, so its behavior is unchanged.

## Notes

- The layout-timing part of the report (stale bounds during `resetComponents()`) was already addressed by #503 — the `stackView?.layoutIfNeeded()` / `cropStackView.layoutIfNeeded()` calls are present in `viewDidLayoutSubviews()`.
- Verified with a simulator build (`BUILD SUCCEEDED`).

Credit to @stevengoldberg for the detailed diagnosis in #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embedded crop toolbar layout so it no longer applies safe-area insets twice.
  * Improved alignment of the crop view in embedded mode while keeping non-embedded behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->