### PR TITLE
fix: avoid initial-display zoom flicker in fixed-ratio crop (#487)

### DIFF
--- a/Sources/Mantis/CropView/CropView+Layout.swift
+++ b/Sources/Mantis/CropView/CropView+Layout.swift
@@ -180,7 +180,11 @@ extension CropView {
                 cropWorkbenchView.zoom(to: zoomRect, animated: false)
             }
             cropWorkbenchView.updateContentOffset()
-            makeSureImageContainsCropOverlay()
+            // Mirror the caller's animation intent for the containment correction.
+            // When the crop adjustment itself is non-animated (e.g. the fixed-ratio
+            // path during the initial resetComponents()), an animated zoomScaleToBound
+            // here produces a visible zoom-in/zoom-out flicker on first display.
+            makeSureImageContainsCropOverlay(animated: animation)
         }
         
         if animation {
@@ -197,7 +201,7 @@ extension CropView {
         isManuallyZoomed = true
     }
     
-    func makeSureImageContainsCropOverlay() {
+    func makeSureImageContainsCropOverlay(animated: Bool = true) {
         let hasSkew = viewModel.horizontalSkewDegrees != 0 || viewModel.verticalSkewDegrees != 0
 
         if hasSkew {
@@ -211,7 +215,7 @@ extension CropView {
             // to keep the overlay inside the projected image.
         } else {
             if !imageContainer.contains(rect: cropAuxiliaryIndicatorView.frame, fromView: self, tolerance: 0.25) {
-                cropWorkbenchView.zoomScaleToBound(animated: true)
+                cropWorkbenchView.zoomScaleToBound(animated: animated)
             }
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #521 for the third issue raised in #487 — a visible zoom-in/zoom-out animation on the **first display** of a fixed-ratio crop.

`adjustUIForNewCrop(...)` always ran its `makeSureImageContainsCropOverlay()` containment correction with an **animated** `zoomScaleToBound`, even when the crop adjustment itself was requested non-animated (`animation: false`). On the initial `resetComponents()` for a fixed ratio — the `.none` preset + `alwaysUsingOnePresetFixedRatio` path, which reaches `setFixedRatioCropBox(...)` → `adjustUIForNewCrop(animation: false, ...)` — a slightly-off containment check then animates a zoom correction, producing a visible flicker on first appearance. The `.presetInfo` path doesn't hit this because it uses `setFixedRatioCropBox(zoom: false)`.

## Change

Thread the caller's animation intent into `makeSureImageContainsCropOverlay(animated:)`, so a non-animated crop adjustment yields a non-animated containment correction:

- `makeSureImageContainsCropOverlay(animated: Bool = true)` — new param, forwarded to `zoomScaleToBound(animated:)`.
- Inside `adjustUIForNewCrop`'s `updateUI`, call `makeSureImageContainsCropOverlay(animated: animation)`.

**Geometry is unchanged** — only the spurious animation is removed. All other callers (rotation, scroll-view delegate, the rotation-preserving reset path, touches) keep the default `animated: true`, so interactive drag / rotation snap-back behavior is unaffected.

## Notes

- Builds cleanly against the iOS 27 SDK (`BUILD SUCCEEDED`).
- This is intentionally the surgical option (removing only the animation) rather than switching the reset path to `zoom: false`, to avoid changing the proven crop-box geometry that the reset (`didSelectReset`) path relies on.

Credit to @stevengoldberg for the diagnosis in #487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crop adjustment behavior to reduce a brief zoom flicker when the crop overlay is first applied.
  * Crop containment corrections now follow the intended animation behavior more consistently, making initial crop changes feel smoother.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->