### PR TITLE
feat: add PrivacyInfo.xcprivacy privacy manifest

### DIFF
--- a/Mantis.podspec
+++ b/Mantis.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/guoyingtao/Mantis.git", :tag => "v#{s.version}" }
   s.source_files  = "Sources/**/*.{h,swift}"
   s.resource_bundles = {
-    "MantisResources" => ["Sources/**/*.lproj/*.strings"]
+    "MantisResources" => ["Sources/**/*.lproj/*.strings", "Sources/Mantis/PrivacyInfo.xcprivacy"]
   }
   
   s.pod_target_xcconfig = {

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		A1A1A1A1000000000000AA02 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */; };
 		269AF94227437EE400F7FAF6 /* RotationDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269AF94127437EE400F7FAF6 /* RotationDialConfig.swift */; };
 		5F17E40A253535F300A3EB7D /* Orientation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F17E409253535F300A3EB7D /* Orientation.swift */; };
 		5F69CC5E26C0629400568B75 /* Definition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F69CC5D26C0629400568B75 /* Definition.swift */; };
@@ -164,6 +165,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		269AF94127437EE400F7FAF6 /* RotationDialConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationDialConfig.swift; sourceTree = "<group>"; };
 		5F17E409253535F300A3EB7D /* Orientation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Orientation.swift; sourceTree = "<group>"; };
 		5F69CC5D26C0629400568B75 /* Definition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Definition.swift; sourceTree = "<group>"; };
@@ -570,6 +572,7 @@
 				F2D700372DA1B8490063EE6C /* SwiftUIView */,
 				66100E05294B7040001C8593 /* Protocols */,
 				OBJ_9 /* Mantis.h */,
+				A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */,
 				OBJ_36 /* Mantis.swift */,
 				6659429C2877DAE80096A5DB /* Config.swift */,
 				663FCF3728866DDA003D3B9E /* CropViewConfig.swift */,
@@ -724,6 +727,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8EFB6FB125D187A000C0DDB2 /* Resource.bundle in Resources */,
+				A1A1A1A1000000000000AA02 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .target(
             name: "Mantis",
             exclude: ["Info.plist", "Resources/Info.plist"],
-            resources: [.process("Resources")],
+            resources: [.process("Resources"), .copy("PrivacyInfo.xcprivacy")],
             swiftSettings: [.define("MANTIS_SPM")]
         )
     ]

--- a/Sources/Mantis/PrivacyInfo.xcprivacy
+++ b/Sources/Mantis/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Adds an empty `PrivacyInfo.xcprivacy` privacy manifest to the Mantis SDK.

Mantis uses **no required-reason APIs** (no `UserDefaults`, file timestamp, disk space, system boot time, or active keyboard APIs) and **collects no data**, so a privacy manifest is **not** a hard compliance requirement. However, an empty manifest costs essentially nothing to ship and removes uncertainty for adopters when the App Store scans bundled third-party SDKs at submission time.

The manifest declares:
- `NSPrivacyTracking` = `false`
- `NSPrivacyTrackingDomains` = empty
- `NSPrivacyCollectedDataTypes` = empty
- `NSPrivacyAccessedAPITypes` = empty

## Distribution channels wired up

The manifest is included across all three ways Mantis is consumed, so the file lands in the SDK bundle regardless of integration method:

- **Swift Package Manager** — added as a `.copy("PrivacyInfo.xcprivacy")` resource in `Package.swift`.
- **CocoaPods** — added to the `MantisResources` resource bundle in `Mantis.podspec`.
- **Carthage / direct Xcode** — added as a file reference and to the `Mantis` framework target's Copy Bundle Resources in `Mantis.xcodeproj`.

## Verification

- `plutil -lint` passes for both `PrivacyInfo.xcprivacy` and `project.pbxproj`.
- `swift package dump-package` resolves cleanly with the new resource.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a privacy manifest to the app/library package resources.
  * Ensures the privacy file is included in distributed builds and bundled with the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->