### PR TITLE
refactor: extract pure skew positioning math into SkewPositioning + tests

### DIFF
--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		A1A1A1A1000000000000AA02 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */; };
 		AA00000000000000000000A1 /* CICropEquivalenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000A2 /* CICropEquivalenceTests.swift */; };
 		AA00000000000000000000B1 /* PerspectiveTransformHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */; };
+		AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000F2 /* SkewPositioningTests.swift */; };
 		AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000C2 /* GeometryHelperTests.swift */; };
 		AA00000000000000000000D1 /* UIImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000D2 /* UIImageExtensionsTests.swift */; };
 		F2058F252A4004E3008DEBAA /* SlideDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */; };
@@ -88,6 +89,7 @@
 		F24DCFEC29AF2A6000D8E8C1 /* CropAuxiliaryIndicatorView+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24DCFEB29AF2A6000D8E8C1 /* CropAuxiliaryIndicatorView+Accessibility.swift */; };
 		F251B36E299B9A52006325B0 /* CropWorkbenchViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F251B36D299B9A52006325B0 /* CropWorkbenchViewTests.swift */; };
 		F25821622F41800F0091CA49 /* PerspectiveTransformHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25821612F41800F0091CA49 /* PerspectiveTransformHelper.swift */; };
+		AA00000000000000000000E1 /* SkewPositioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000E2 /* SkewPositioning.swift */; };
 		F25821642F4180880091CA49 /* RotationTypeSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = F25821632F4180880091CA49 /* RotationTypeSelector.swift */; };
 		F262471B2F4B594300DD5BCE /* CropView+Skew.swift in Sources */ = {isa = PBXBuildFile; fileRef = F262471A2F4B594300DD5BCE /* CropView+Skew.swift */; };
 		F262471D2F4B596C00DD5BCE /* CropView+Crop.swift in Sources */ = {isa = PBXBuildFile; fileRef = F262471C2F4B596C00DD5BCE /* CropView+Crop.swift */; };
@@ -231,6 +233,7 @@
 		A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA00000000000000000000A2 /* CICropEquivalenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CICropEquivalenceTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerspectiveTransformHelperTests.swift; sourceTree = "<group>"; };
+		AA00000000000000000000F2 /* SkewPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkewPositioningTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000C2 /* GeometryHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryHelperTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000D2 /* UIImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensionsTests.swift; sourceTree = "<group>"; };
 		E86127BD26206D01008365BC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MantisLocalizable.strings; sourceTree = "<group>"; };
@@ -248,6 +251,7 @@
 		F24DCFEB29AF2A6000D8E8C1 /* CropAuxiliaryIndicatorView+Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CropAuxiliaryIndicatorView+Accessibility.swift"; sourceTree = "<group>"; };
 		F251B36D299B9A52006325B0 /* CropWorkbenchViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropWorkbenchViewTests.swift; sourceTree = "<group>"; };
 		F25821612F41800F0091CA49 /* PerspectiveTransformHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerspectiveTransformHelper.swift; sourceTree = "<group>"; };
+		AA00000000000000000000E2 /* SkewPositioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkewPositioning.swift; sourceTree = "<group>"; };
 		F25821632F4180880091CA49 /* RotationTypeSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationTypeSelector.swift; sourceTree = "<group>"; };
 		F262471A2F4B594300DD5BCE /* CropView+Skew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CropView+Skew.swift"; sourceTree = "<group>"; };
 		F262471C2F4B596C00DD5BCE /* CropView+Crop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CropView+Crop.swift"; sourceTree = "<group>"; };
@@ -476,6 +480,7 @@
 			isa = PBXGroup;
 			children = (
 				F25821612F41800F0091CA49 /* PerspectiveTransformHelper.swift */,
+				AA00000000000000000000E2 /* SkewPositioning.swift */,
 				97D3A0182BAD491A00DEB1D6 /* TransformRecord.swift */,
 				97D3A0172BAD491A00DEB1D6 /* TransformStack.swift */,
 				F2AD53402A46DB8B00AE9C87 /* ImageAutoAdjustHelper.swift */,
@@ -550,6 +555,7 @@
 				97FA9A842BAFA570001E67D9 /* TransformStackTests.swift */,
 				AA00000000000000000000A2 /* CICropEquivalenceTests.swift */,
 				AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */,
+				AA00000000000000000000F2 /* SkewPositioningTests.swift */,
 				AA00000000000000000000C2 /* GeometryHelperTests.swift */,
 				AA00000000000000000000D2 /* UIImageExtensionsTests.swift */,
 			);
@@ -795,6 +801,7 @@
 				97FA9A852BAFA570001E67D9 /* TransformStackTests.swift in Sources */,
 				AA00000000000000000000A1 /* CICropEquivalenceTests.swift in Sources */,
 				AA00000000000000000000B1 /* PerspectiveTransformHelperTests.swift in Sources */,
+				AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */,
 				AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */,
 				AA00000000000000000000D1 /* UIImageExtensionsTests.swift in Sources */,
 				F24DCFE629A9E53E00D8E8C1 /* UIViewExtensions.swift in Sources */,
@@ -835,6 +842,7 @@
 				OBJ_72 /* CropAuxiliaryIndicatorView.swift in Sources */,
 				F209F88C2F4D756D00E15AEA /* SlideDialIconDrawer.swift in Sources */,
 				F25821622F41800F0091CA49 /* PerspectiveTransformHelper.swift in Sources */,
+				AA00000000000000000000E1 /* SkewPositioning.swift in Sources */,
 				OBJ_73 /* CropWorkbenchView.swift in Sources */,
 				66F909BF287D22E7007E2FC6 /* ToolBarButtonImageBuilder+DrawImage.swift in Sources */,
 				OBJ_74 /* CropView+Touches.swift in Sources */,

--- a/Sources/Mantis/CropView/CropView+Skew.swift
+++ b/Sources/Mantis/CropView/CropView+Skew.swift
@@ -7,40 +7,10 @@
 
 import UIKit
 
-/// Tuning constants for the perspective-skew positioning math. Collecting the
-/// transition angles, dampening ramps, and epsilons here — instead of scattering
-/// them as inline literals — makes each value named, documented, and adjustable
-/// in one place. Values are unchanged from the original inline constants.
-private enum SkewTuning {
-    /// Angle (°) at which edge-to-edge alignment starts blending toward the
-    /// vertex-to-edge inscribed fit.
-    static let transitionStartDegrees: CGFloat = 8.0
-    /// Angle (°) at which the blend to the inscribed fit completes.
-    static let transitionEndDegrees: CGFloat = 12.0
-    /// Skew degrees over which one axis ramps to "fully active"; used to dampen
-    /// the other axis's edge-to-edge shift and scale boost.
-    static let axisActivityRampDegrees: CGFloat = 3.0
-    /// Skew degrees over which the small-angle scale boost ramps to full intensity.
-    static let scaleBoostRampDegrees: CGFloat = 10.0
-    /// Peak extra scale added at small angles so the projected image has headroom
-    /// for edge-to-edge content-offset positioning.
-    static let maxScaleBoost: CGFloat = 0.04
-    /// Rotation (°) at which edge-to-edge dampening reaches full strength.
-    static let rotationDampenDegrees: CGFloat = 10.0
-    /// Relative tolerance for treating the crop box and image aspect ratios as equal.
-    static let aspectRatioMatchTolerance: CGFloat = 0.05
-    /// Safety inset (pt) guarding against sub-pixel gaps at the crop box edge.
-    static let cropBoxSafetyInset: CGFloat = 2
-    /// Iterations for the shift / offset binary searches.
-    static let binarySearchIterations = 16
-    /// Duration (s) of the pull-back animation after an invalid pan.
-    static let clampAnimationDuration: TimeInterval = 0.15
-    /// Zoom delta above the minimum scale that counts as "zoomed in".
-    static let zoomedInEpsilon: CGFloat = 0.01
-    /// Minimum corner distance (pt) below which safety-inset scaling is skipped,
-    /// avoiding division by a near-zero length.
-    static let minCornerLength: CGFloat = 1e-6
-}
+// Perspective-skew geometry (containment tests, inset/offset math, scale boost)
+// and the `SkewTuning` constants live in the pure, unit-tested `SkewPositioning`
+// component. This file keeps only the view-coupled orchestration that reads the
+// scroll view / view model and applies the results.
 
 /// Groups the mutable state used to smooth and stabilize skew transforms
 /// across consecutive frames. Replacing three loose properties on CropView
@@ -175,7 +145,9 @@ extension CropView {
                 perspectiveTransform: perspectiveTransform
             )
             
-            let edgeBoost = computeEdgeToEdgeScaleBoost(hDeg: hDeg, vDeg: vDeg)
+            let edgeBoost = cropBoxMatchesImageAspectRatio
+                ? SkewPositioning.edgeToEdgeScaleBoost(hDeg: hDeg, vDeg: vDeg)
+                : 1.0
             
             var finalScale = rawScale * edgeBoost
             
@@ -219,18 +191,20 @@ extension CropView {
 
         let newInset: UIEdgeInsets
 
-        if isValidSkewPosition(shiftX: 0, shiftY: 0, context: context) {
-            let shifts = computeMaxShifts(context: context)
-            newInset = computeSkewContentInset(shifts: shifts, context: context)
+        if SkewPositioning.isCropBoxInside(shiftX: 0, shiftY: 0, context: context) {
+            let shifts = SkewPositioning.maxShifts(context: context)
+            newInset = SkewPositioning.contentInset(shifts: shifts, context: context)
 
-            let optimalOffset = computeOptimalSkewOffset(
-                hDeg: hDeg, vDeg: vDeg, shifts: shifts, context: context
+            let optimalOffset = SkewPositioning.optimalOffset(
+                hDeg: hDeg, vDeg: vDeg, shifts: shifts, context: context,
+                matchesAspectRatio: cropBoxMatchesImageAspectRatio,
+                totalRadians: viewModel.getTotalRadians()
             )
             applySkewContentOffset(optimalOffset: optimalOffset, inset: newInset, context: context)
         } else {
             // Center-based test fails — the projected image at the center
             // anchor is too small to cover the crop box. Lock to center.
-            newInset = computeLockedCenterInset(context: context)
+            newInset = SkewPositioning.lockedCenterInset(context: context)
         }
 
         // Guard against non-finite inset values that can arise from
@@ -277,11 +251,11 @@ extension CropView {
         var targetX = max(-inset.left, min(maxOffsetX, curOffset.x))
         var targetY = max(-inset.top, min(maxOffsetY, curOffset.y))
 
-        if !isValidSkewOffset(offsetX: targetX, offsetY: targetY, context: context) {
+        if !SkewPositioning.isCropBoxInside(offsetX: targetX, offsetY: targetY, context: context) {
             let centerX = context.centerOffset.x
             let centerY = context.centerOffset.y
 
-            if isValidSkewOffset(offsetX: centerX, offsetY: centerY, context: context) {
+            if SkewPositioning.isCropBoxInside(offsetX: centerX, offsetY: centerY, context: context) {
                 // Binary-search along the line from current position toward center
                 // to find the nearest valid point.
                 var lowerBound: CGFloat = 0  // center
@@ -290,7 +264,7 @@ extension CropView {
                     let mid = (lowerBound + upperBound) / 2
                     let testX = centerX + (targetX - centerX) * mid
                     let testY = centerY + (targetY - centerY) * mid
-                    if isValidSkewOffset(offsetX: testX, offsetY: testY, context: context) {
+                    if SkewPositioning.isCropBoxInside(offsetX: testX, offsetY: testY, context: context) {
                         lowerBound = mid
                     } else {
                         upperBound = mid
@@ -390,257 +364,12 @@ extension CropView {
     }
 }
 
-// MARK: - Skew Inset Context & Helpers
+// MARK: - Skew Offset Application (view-coupled)
 
 extension CropView {
-    /// Groups the shared geometric state needed by skew inset/offset calculations,
-    /// avoiding repeated property lookups and keeping helper signatures clean.
-    struct SkewInsetContext {
-        let imageFrame: CGRect
-        let boundsSize: CGSize
-        let contentSize: CGSize
-        let cropCorners: [CGPoint]
-        let transform: CATransform3D
-        
-        var centerOffset: CGPoint {
-            CGPoint(
-                x: imageFrame.midX - boundsSize.width / 2,
-                y: imageFrame.midY - boundsSize.height / 2
-            )
-        }
-        
-        /// Image corner displacements from a given anchor point.
-        func imageCornerDisplacements(from anchor: CGPoint) -> [CGPoint] {
-            [
-                CGPoint(x: imageFrame.minX - anchor.x, y: imageFrame.minY - anchor.y),
-                CGPoint(x: imageFrame.maxX - anchor.x, y: imageFrame.minY - anchor.y),
-                CGPoint(x: imageFrame.maxX - anchor.x, y: imageFrame.maxY - anchor.y),
-                CGPoint(x: imageFrame.minX - anchor.x, y: imageFrame.maxY - anchor.y)
-            ]
-        }
-    }
-    
-    /// Directional shift distances used to compute insets and optimal offsets.
-    struct SkewShifts {
-        let top: CGFloat
-        let left: CGFloat
-        let bottom: CGFloat
-        let right: CGFloat
-        
-        var centeredShiftX: CGFloat { (right - left) / 2 }
-        var centeredShiftY: CGFloat { (bottom - top) / 2 }
-    }
-    
-    // MARK: Validation
-    
-    /// Tests whether shifting the viewport by (shiftX, shiftY) from the image center
-    /// keeps the crop box fully inside the projected (skewed) image quad.
-    func isValidSkewPosition(shiftX: CGFloat, shiftY: CGFloat, context: SkewInsetContext) -> Bool {
-        let anchor = CGPoint(
-            x: context.centerOffset.x + shiftX + context.boundsSize.width / 2,
-            y: context.centerOffset.y + shiftY + context.boundsSize.height / 2
-        )
-        let corners = context.imageCornerDisplacements(from: anchor)
-        // Reject positions where any image corner is behind the camera
-        // (w ≤ 0). At extreme skew angles a large shift can push corners
-        // past the vanishing plane, flipping the projected polygon and
-        // making the ray-casting containment test unreliable.
-        guard PerspectiveTransformHelper.allProjectionsInFrontOfCamera(corners, through: context.transform) else {
-            return false
-        }
-        let proj = corners.map {
-            PerspectiveTransformHelper.projectDisplacement($0, through: context.transform)
-        }
-        return PerspectiveTransformHelper.allPointsInsideConvexPolygon(context.cropCorners, polygon: proj)
-    }
-    
-    /// Tests whether a given contentOffset keeps the crop box inside the projected image quad.
-    /// Used by `clampContentOffsetForSkewIfNeeded` for post-pan validation.
-    func isValidSkewOffset(offsetX: CGFloat, offsetY: CGFloat, context: SkewInsetContext) -> Bool {
-        let anchor = CGPoint(x: offsetX + context.boundsSize.width / 2,
-                             y: offsetY + context.boundsSize.height / 2)
-        let corners = context.imageCornerDisplacements(from: anchor)
-        guard PerspectiveTransformHelper.allProjectionsInFrontOfCamera(corners, through: context.transform) else {
-            return false
-        }
-        let proj = corners.map {
-            PerspectiveTransformHelper.projectDisplacement($0, through: context.transform)
-        }
-        return PerspectiveTransformHelper.allPointsInsideConvexPolygon(context.cropCorners, polygon: proj)
-    }
-    
-    // MARK: Shift Computation
-    
-    /// Binary-searches for the maximum valid shift distance along each cardinal direction.
-    func computeMaxShifts(context: SkewInsetContext) -> SkewShifts {
-        SkewShifts(
-            top: maxShiftInDirection(dirX: 0, dirY: -1, context: context),
-            left: maxShiftInDirection(dirX: -1, dirY: 0, context: context),
-            bottom: maxShiftInDirection(dirX: 0, dirY: 1, context: context),
-            right: maxShiftInDirection(dirX: 1, dirY: 0, context: context)
-        )
-    }
-    
-    /// Binary-search for the max valid distance along a single direction.
-    private func maxShiftInDirection(dirX: CGFloat, dirY: CGFloat, context: SkewInsetContext) -> CGFloat {
-        // Use the image frame size so the search range covers the full
-        // pannable area at any zoom level. Using only bounds would cap
-        // the shift at the viewport size, rejecting valid positions when
-        // zoomed in.
-        let maxDist = max(context.imageFrame.width, context.imageFrame.height)
-        var lowerBound: CGFloat = 0
-        var upperBound: CGFloat = maxDist
-        for _ in 0..<SkewTuning.binarySearchIterations {
-            let mid = (lowerBound + upperBound) / 2
-            if isValidSkewPosition(shiftX: dirX * mid, shiftY: dirY * mid, context: context) {
-                lowerBound = mid
-            } else {
-                upperBound = mid
-            }
-        }
-        return lowerBound
-    }
-    
-    // MARK: Inset Computation
-    
-    /// Converts shift distances into UIScrollView contentInset values.
-    ///
-    /// The shift represents displacement of contentOffset from centerOffset
-    /// (the offset that centers the image in the viewport).
-    /// These can be NEGATIVE when skew + rotation restricts the pan range
-    /// below the scroll view's default.
-    func computeSkewContentInset(shifts: SkewShifts, context: SkewInsetContext) -> UIEdgeInsets {
-        let center = context.centerOffset
-        let contentWidth = context.contentSize.width
-        let contentHeight = context.contentSize.height
-        let boundsWidth = context.boundsSize.width
-        let boundsHeight = context.boundsSize.height
-        
-        return UIEdgeInsets(
-            top: shifts.top - center.y,
-            left: shifts.left - center.x,
-            bottom: (center.y + shifts.bottom) - (contentHeight - boundsHeight),
-            right: (center.x + shifts.right) - (contentWidth - boundsWidth)
-        )
-    }
-    
-    /// Fallback inset that locks the viewport to the image center.
-    private func computeLockedCenterInset(context: SkewInsetContext) -> UIEdgeInsets {
-        let center = context.centerOffset
-        let boundsWidth = context.boundsSize.width
-        let boundsHeight = context.boundsSize.height
-        return UIEdgeInsets(
-            top: -center.y,
-            left: -center.x,
-            bottom: center.y - (context.contentSize.height - boundsHeight),
-            right: center.x - (context.contentSize.width - boundsWidth)
-        )
-    }
-    
-    // MARK: Optimal Offset (Two-Phase Positioning)
-    
-    /// Computes the optimal content offset for the current skew angle.
-    ///
-    /// **Phase 1** (|deg| ≤ ~10°, single-axis only): edge-to-edge — align the crop
-    /// box edge toward the vanishing point flush with the skewed image edge.
-    ///
-    /// **Phase 2** (|deg| > ~10° or both axes active): vertex-to-edge inscribed —
-    /// center the crop box in the valid range so vertices touch opposite edges.
-    ///
-    /// A smooth blend between 8°–12° avoids visual jumps at the threshold.
-    func computeOptimalSkewOffset(
-        hDeg: CGFloat,
-        vDeg: CGFloat,
-        shifts: SkewShifts,
-        context: SkewInsetContext
-    ) -> CGPoint {
-        let centeredX = shifts.centeredShiftX
-        let centeredY = shifts.centeredShiftY
-        
-        let optimalShiftX: CGFloat
-        let optimalShiftY: CGFloat
-        
-        if cropBoxMatchesImageAspectRatio {
-            let totalRadians = viewModel.getTotalRadians()
-            
-            // Rotation dampening: full dampening at ±10° of rotation.
-            let rotationDampen = max(1 - abs(totalRadians) / (SkewTuning.rotationDampenDegrees * .pi / 180), 0)
-            
-            // Cross-axis dampening: when the other axis has skew, the
-            // combined perspective makes single-axis shift extremes unstable.
-            let hActivity = min(abs(hDeg) / SkewTuning.axisActivityRampDegrees, 1.0)
-            let vActivity = min(abs(vDeg) / SkewTuning.axisActivityRampDegrees, 1.0)
-            
-            optimalShiftY = computeEdgeToEdgeShift(
-                deg: vDeg,
-                positiveEdgeShift: -shifts.top,
-                negativeEdgeShift: shifts.bottom,
-                centeredShift: centeredY,
-                rotationDampen: rotationDampen,
-                crossAxisActivity: hActivity
-            )
-            
-            optimalShiftX = computeEdgeToEdgeShift(
-                deg: hDeg,
-                positiveEdgeShift: shifts.right,
-                negativeEdgeShift: -shifts.left,
-                centeredShift: centeredX,
-                rotationDampen: rotationDampen,
-                crossAxisActivity: vActivity
-            )
-        } else {
-            // Non-original aspect ratio: skip edge-to-edge, use centered.
-            optimalShiftX = centeredX
-            optimalShiftY = centeredY
-        }
-        
-        let center = context.centerOffset
-        return CGPoint(x: center.x + optimalShiftX, y: center.y + optimalShiftY)
-    }
-    
-    /// Computes the blended shift for a single axis, transitioning from
-    /// edge-to-edge alignment (small angles) to centered/inscribed (large angles).
-    ///
-    /// - Parameters:
-    ///   - deg: Skew degrees on this axis (sign determines direction).
-    ///   - positiveEdgeShift: Shift value when deg > 0 (toward vanishing edge).
-    ///   - negativeEdgeShift: Shift value when deg < 0 (toward vanishing edge).
-    ///   - centeredShift: Centered (inscribed) shift for this axis.
-    ///   - rotationDampen: Dampening factor from scroll view rotation [0..1].
-    ///   - crossAxisActivity: How active the other axis is [0..1], used for dampening.
-    private func computeEdgeToEdgeShift(
-        deg: CGFloat,
-        positiveEdgeShift: CGFloat,
-        negativeEdgeShift: CGFloat,
-        centeredShift: CGFloat,
-        rotationDampen: CGFloat,
-        crossAxisActivity: CGFloat
-    ) -> CGFloat {
-        let transitionStart = SkewTuning.transitionStartDegrees
-        let transitionEnd = SkewTuning.transitionEndDegrees
-
-        let dampen = rotationDampen * (1 - crossAxisActivity)
-        
-        let rawEdgeAligned: CGFloat
-        if deg > 0 {
-            rawEdgeAligned = positiveEdgeShift
-        } else if deg < 0 {
-            rawEdgeAligned = negativeEdgeShift
-        } else {
-            rawEdgeAligned = centeredShift
-        }
-        
-        let edgeAligned = centeredShift + (rawEdgeAligned - centeredShift) * dampen
-        let absDeg = abs(deg)
-        let blend = min(max((absDeg - transitionStart) / (transitionEnd - transitionStart), 0), 1)
-        return edgeAligned + (centeredShift - edgeAligned) * blend
-    }
-    
-    // MARK: Offset Application
-    
     /// Applies the computed optimal offset to the scroll view, preserving the
     /// user's manual panning by applying only the delta from the previous optimal.
-    private func applySkewContentOffset(
+    func applySkewContentOffset(
         optimalOffset: CGPoint,
         inset: UIEdgeInsets,
         context: SkewInsetContext
@@ -708,37 +437,6 @@ extension CropView {
         }
         
         skewState.previousOptimalOffset = optimalOffset
-    }
-    
-    // MARK: Scale Boost
-    
-    /// Edge-to-edge scale boost: at small angles, the inscribed-fit scale leaves
-    /// no room for content offset shifting. This adds a small extra factor so
-    /// the projected image is slightly larger than the minimum, giving
-    /// `updateContentInsetForSkew` headroom to position the crop box flush
-    /// against the vanishing-point edge.
-    ///
-    /// The boost ramps up linearly with |deg|, peaks around 8-10°, then fades
-    /// to 0 at 12° where the vertex-to-edge inscribed behavior takes over.
-    /// Skipped when the crop box has a different aspect ratio from the image.
-    private func computeEdgeToEdgeScaleBoost(hDeg: CGFloat, vDeg: CGFloat) -> CGFloat {
-        guard cropBoxMatchesImageAspectRatio else { return 1.0 }
-        
-        let transitionEnd = SkewTuning.transitionEndDegrees
-        let absH = abs(hDeg)
-        let absV = abs(vDeg)
-        let hActivity = min(absH / SkewTuning.axisActivityRampDegrees, 1.0)
-        let vActivity = min(absV / SkewTuning.axisActivityRampDegrees, 1.0)
-        
-        // Each axis's boost is dampened by the other axis's activity.
-        let hEdgeFade = max(1 - absH / transitionEnd, 0) * (1 - vActivity)
-        let vEdgeFade = max(1 - absV / transitionEnd, 0) * (1 - hActivity)
-        
-        // Scale the boost by how much skew there is (normalized to 0-1
-        // within the edge-to-edge range).
-        let hBoostIntensity = min(absH / SkewTuning.scaleBoostRampDegrees, 1.0) * hEdgeFade
-        let vBoostIntensity = min(absV / SkewTuning.scaleBoostRampDegrees, 1.0) * vEdgeFade
-        return 1.0 + SkewTuning.maxScaleBoost * max(hBoostIntensity, vBoostIntensity)
     }
     
     // MARK: State Reset

--- a/Sources/Mantis/Helpers/SkewPositioning.swift
+++ b/Sources/Mantis/Helpers/SkewPositioning.swift
@@ -1,0 +1,336 @@
+//
+//  SkewPositioning.swift
+//  Mantis
+//
+//  Pure, UIKit-free geometry backing the perspective-skew crop preview.
+//
+//  These functions were extracted verbatim from `CropView+Skew.swift`. They
+//  take plain value types (`SkewInsetContext`, `SkewShifts`, CGFloats) and
+//  return plain values — no view, view-model, or scroll-view state — so their
+//  behavior can be pinned by unit tests. That matters because the live preview
+//  keeps three sources of truth (view-model angle, sublayerTransform,
+//  contentInset) in manual sync, making regressions in this math easy to
+//  introduce and hard to spot visually.
+//
+
+import CoreGraphics
+import UIKit
+
+/// Tuning constants for the perspective-skew positioning math. Collecting the
+/// transition angles, dampening ramps, and epsilons here — instead of scattering
+/// them as inline literals — makes each value named, documented, and adjustable
+/// in one place.
+enum SkewTuning {
+    /// Angle (°) at which edge-to-edge alignment starts blending toward the
+    /// vertex-to-edge inscribed fit.
+    static let transitionStartDegrees: CGFloat = 8.0
+    /// Angle (°) at which the blend to the inscribed fit completes.
+    static let transitionEndDegrees: CGFloat = 12.0
+    /// Skew degrees over which one axis ramps to "fully active"; used to dampen
+    /// the other axis's edge-to-edge shift and scale boost.
+    static let axisActivityRampDegrees: CGFloat = 3.0
+    /// Skew degrees over which the small-angle scale boost ramps to full intensity.
+    static let scaleBoostRampDegrees: CGFloat = 10.0
+    /// Peak extra scale added at small angles so the projected image has headroom
+    /// for edge-to-edge content-offset positioning.
+    static let maxScaleBoost: CGFloat = 0.04
+    /// Rotation (°) at which edge-to-edge dampening reaches full strength.
+    static let rotationDampenDegrees: CGFloat = 10.0
+    /// Relative tolerance for treating the crop box and image aspect ratios as equal.
+    static let aspectRatioMatchTolerance: CGFloat = 0.05
+    /// Safety inset (pt) guarding against sub-pixel gaps at the crop box edge.
+    static let cropBoxSafetyInset: CGFloat = 2
+    /// Iterations for the shift / offset binary searches.
+    static let binarySearchIterations = 16
+    /// Duration (s) of the pull-back animation after an invalid pan.
+    static let clampAnimationDuration: TimeInterval = 0.15
+    /// Zoom delta above the minimum scale that counts as "zoomed in".
+    static let zoomedInEpsilon: CGFloat = 0.01
+    /// Minimum corner distance (pt) below which safety-inset scaling is skipped,
+    /// avoiding division by a near-zero length.
+    static let minCornerLength: CGFloat = 1e-6
+}
+
+/// Groups the shared geometric state needed by skew inset/offset calculations,
+/// avoiding repeated property lookups and keeping helper signatures clean.
+struct SkewInsetContext {
+    let imageFrame: CGRect
+    let boundsSize: CGSize
+    let contentSize: CGSize
+    let cropCorners: [CGPoint]
+    let transform: CATransform3D
+
+    var centerOffset: CGPoint {
+        CGPoint(
+            x: imageFrame.midX - boundsSize.width / 2,
+            y: imageFrame.midY - boundsSize.height / 2
+        )
+    }
+
+    /// Image corner displacements from a given anchor point.
+    func imageCornerDisplacements(from anchor: CGPoint) -> [CGPoint] {
+        [
+            CGPoint(x: imageFrame.minX - anchor.x, y: imageFrame.minY - anchor.y),
+            CGPoint(x: imageFrame.maxX - anchor.x, y: imageFrame.minY - anchor.y),
+            CGPoint(x: imageFrame.maxX - anchor.x, y: imageFrame.maxY - anchor.y),
+            CGPoint(x: imageFrame.minX - anchor.x, y: imageFrame.maxY - anchor.y)
+        ]
+    }
+}
+
+/// Directional shift distances used to compute insets and optimal offsets.
+struct SkewShifts {
+    let top: CGFloat
+    let left: CGFloat
+    let bottom: CGFloat
+    let right: CGFloat
+
+    var centeredShiftX: CGFloat { (right - left) / 2 }
+    var centeredShiftY: CGFloat { (bottom - top) / 2 }
+}
+
+/// Pure geometry for positioning the crop box within the projected (skewed)
+/// image quad. Stateless — every input arrives via parameters.
+enum SkewPositioning {
+
+    // MARK: Validation
+
+    /// Tests whether shifting the viewport by (shiftX, shiftY) from the image center
+    /// keeps the crop box fully inside the projected (skewed) image quad.
+    static func isCropBoxInside(shiftX: CGFloat, shiftY: CGFloat, context: SkewInsetContext) -> Bool {
+        let anchor = CGPoint(
+            x: context.centerOffset.x + shiftX + context.boundsSize.width / 2,
+            y: context.centerOffset.y + shiftY + context.boundsSize.height / 2
+        )
+        return isCropBoxInside(anchor: anchor, context: context)
+    }
+
+    /// Tests whether a given contentOffset keeps the crop box inside the projected image quad.
+    /// Used by `clampContentOffsetForSkewIfNeeded` for post-pan validation.
+    static func isCropBoxInside(offsetX: CGFloat, offsetY: CGFloat, context: SkewInsetContext) -> Bool {
+        let anchor = CGPoint(x: offsetX + context.boundsSize.width / 2,
+                             y: offsetY + context.boundsSize.height / 2)
+        return isCropBoxInside(anchor: anchor, context: context)
+    }
+
+    /// Shared containment test: projects the image corners (as displacements
+    /// from `anchor`) through the perspective transform and checks the crop box
+    /// lies inside the resulting quad.
+    private static func isCropBoxInside(anchor: CGPoint, context: SkewInsetContext) -> Bool {
+        let corners = context.imageCornerDisplacements(from: anchor)
+        // Reject positions where any image corner is behind the camera
+        // (w ≤ 0). At extreme skew angles a large shift can push corners
+        // past the vanishing plane, flipping the projected polygon and
+        // making the ray-casting containment test unreliable.
+        guard PerspectiveTransformHelper.allProjectionsInFrontOfCamera(corners, through: context.transform) else {
+            return false
+        }
+        let proj = corners.map {
+            PerspectiveTransformHelper.projectDisplacement($0, through: context.transform)
+        }
+        return PerspectiveTransformHelper.allPointsInsideConvexPolygon(context.cropCorners, polygon: proj)
+    }
+
+    // MARK: Shift Computation
+
+    /// Binary-searches for the maximum valid shift distance along each cardinal direction.
+    static func maxShifts(context: SkewInsetContext) -> SkewShifts {
+        SkewShifts(
+            top: maxShift(dirX: 0, dirY: -1, context: context),
+            left: maxShift(dirX: -1, dirY: 0, context: context),
+            bottom: maxShift(dirX: 0, dirY: 1, context: context),
+            right: maxShift(dirX: 1, dirY: 0, context: context)
+        )
+    }
+
+    /// Binary-search for the max valid distance along a single direction.
+    static func maxShift(dirX: CGFloat, dirY: CGFloat, context: SkewInsetContext) -> CGFloat {
+        // Use the image frame size so the search range covers the full
+        // pannable area at any zoom level. Using only bounds would cap
+        // the shift at the viewport size, rejecting valid positions when
+        // zoomed in.
+        let maxDist = max(context.imageFrame.width, context.imageFrame.height)
+        var lowerBound: CGFloat = 0
+        var upperBound: CGFloat = maxDist
+        for _ in 0..<SkewTuning.binarySearchIterations {
+            let mid = (lowerBound + upperBound) / 2
+            if isCropBoxInside(shiftX: dirX * mid, shiftY: dirY * mid, context: context) {
+                lowerBound = mid
+            } else {
+                upperBound = mid
+            }
+        }
+        return lowerBound
+    }
+
+    // MARK: Inset Computation
+
+    /// Converts shift distances into UIScrollView contentInset values.
+    ///
+    /// The shift represents displacement of contentOffset from centerOffset
+    /// (the offset that centers the image in the viewport).
+    /// These can be NEGATIVE when skew + rotation restricts the pan range
+    /// below the scroll view's default.
+    static func contentInset(shifts: SkewShifts, context: SkewInsetContext) -> UIEdgeInsets {
+        let center = context.centerOffset
+        let contentWidth = context.contentSize.width
+        let contentHeight = context.contentSize.height
+        let boundsWidth = context.boundsSize.width
+        let boundsHeight = context.boundsSize.height
+
+        return UIEdgeInsets(
+            top: shifts.top - center.y,
+            left: shifts.left - center.x,
+            bottom: (center.y + shifts.bottom) - (contentHeight - boundsHeight),
+            right: (center.x + shifts.right) - (contentWidth - boundsWidth)
+        )
+    }
+
+    /// Fallback inset that locks the viewport to the image center.
+    static func lockedCenterInset(context: SkewInsetContext) -> UIEdgeInsets {
+        let center = context.centerOffset
+        let boundsWidth = context.boundsSize.width
+        let boundsHeight = context.boundsSize.height
+        return UIEdgeInsets(
+            top: -center.y,
+            left: -center.x,
+            bottom: center.y - (context.contentSize.height - boundsHeight),
+            right: center.x - (context.contentSize.width - boundsWidth)
+        )
+    }
+
+    // MARK: Optimal Offset (Two-Phase Positioning)
+
+    /// Computes the optimal content offset for the current skew angle.
+    ///
+    /// **Phase 1** (|deg| ≤ ~10°, single-axis only): edge-to-edge — align the crop
+    /// box edge toward the vanishing point flush with the skewed image edge.
+    ///
+    /// **Phase 2** (|deg| > ~10° or both axes active): vertex-to-edge inscribed —
+    /// center the crop box in the valid range so vertices touch opposite edges.
+    ///
+    /// A smooth blend between 8°–12° avoids visual jumps at the threshold.
+    ///
+    /// - Parameters:
+    ///   - matchesAspectRatio: Whether the crop box matches the image aspect
+    ///     ratio; when false the edge-to-edge phase is skipped (centered only).
+    ///   - totalRadians: The scroll view's total rotation, used for dampening.
+    static func optimalOffset(
+        hDeg: CGFloat,
+        vDeg: CGFloat,
+        shifts: SkewShifts,
+        context: SkewInsetContext,
+        matchesAspectRatio: Bool,
+        totalRadians: CGFloat
+    ) -> CGPoint {
+        let centeredX = shifts.centeredShiftX
+        let centeredY = shifts.centeredShiftY
+
+        let optimalShiftX: CGFloat
+        let optimalShiftY: CGFloat
+
+        if matchesAspectRatio {
+            // Rotation dampening: full dampening at ±10° of rotation.
+            let rotationDampen = max(1 - abs(totalRadians) / (SkewTuning.rotationDampenDegrees * .pi / 180), 0)
+
+            // Cross-axis dampening: when the other axis has skew, the
+            // combined perspective makes single-axis shift extremes unstable.
+            let hActivity = min(abs(hDeg) / SkewTuning.axisActivityRampDegrees, 1.0)
+            let vActivity = min(abs(vDeg) / SkewTuning.axisActivityRampDegrees, 1.0)
+
+            optimalShiftY = edgeToEdgeShift(
+                deg: vDeg,
+                positiveEdgeShift: -shifts.top,
+                negativeEdgeShift: shifts.bottom,
+                centeredShift: centeredY,
+                rotationDampen: rotationDampen,
+                crossAxisActivity: hActivity
+            )
+
+            optimalShiftX = edgeToEdgeShift(
+                deg: hDeg,
+                positiveEdgeShift: shifts.right,
+                negativeEdgeShift: -shifts.left,
+                centeredShift: centeredX,
+                rotationDampen: rotationDampen,
+                crossAxisActivity: vActivity
+            )
+        } else {
+            // Non-original aspect ratio: skip edge-to-edge, use centered.
+            optimalShiftX = centeredX
+            optimalShiftY = centeredY
+        }
+
+        let center = context.centerOffset
+        return CGPoint(x: center.x + optimalShiftX, y: center.y + optimalShiftY)
+    }
+
+    /// Computes the blended shift for a single axis, transitioning from
+    /// edge-to-edge alignment (small angles) to centered/inscribed (large angles).
+    ///
+    /// - Parameters:
+    ///   - deg: Skew degrees on this axis (sign determines direction).
+    ///   - positiveEdgeShift: Shift value when deg > 0 (toward vanishing edge).
+    ///   - negativeEdgeShift: Shift value when deg < 0 (toward vanishing edge).
+    ///   - centeredShift: Centered (inscribed) shift for this axis.
+    ///   - rotationDampen: Dampening factor from scroll view rotation [0..1].
+    ///   - crossAxisActivity: How active the other axis is [0..1], used for dampening.
+    static func edgeToEdgeShift(
+        deg: CGFloat,
+        positiveEdgeShift: CGFloat,
+        negativeEdgeShift: CGFloat,
+        centeredShift: CGFloat,
+        rotationDampen: CGFloat,
+        crossAxisActivity: CGFloat
+    ) -> CGFloat {
+        let transitionStart = SkewTuning.transitionStartDegrees
+        let transitionEnd = SkewTuning.transitionEndDegrees
+
+        let dampen = rotationDampen * (1 - crossAxisActivity)
+
+        let rawEdgeAligned: CGFloat
+        if deg > 0 {
+            rawEdgeAligned = positiveEdgeShift
+        } else if deg < 0 {
+            rawEdgeAligned = negativeEdgeShift
+        } else {
+            rawEdgeAligned = centeredShift
+        }
+
+        let edgeAligned = centeredShift + (rawEdgeAligned - centeredShift) * dampen
+        let absDeg = abs(deg)
+        let blend = min(max((absDeg - transitionStart) / (transitionEnd - transitionStart), 0), 1)
+        return edgeAligned + (centeredShift - edgeAligned) * blend
+    }
+
+    // MARK: Scale Boost
+
+    /// Edge-to-edge scale boost: at small angles, the inscribed-fit scale leaves
+    /// no room for content offset shifting. This adds a small extra factor so
+    /// the projected image is slightly larger than the minimum, giving
+    /// `updateContentInsetForSkew` headroom to position the crop box flush
+    /// against the vanishing-point edge.
+    ///
+    /// The boost ramps up linearly with |deg|, peaks around 8-10°, then fades
+    /// to 0 at 12° where the vertex-to-edge inscribed behavior takes over.
+    ///
+    /// Callers should skip this (use 1.0) when the crop box has a different
+    /// aspect ratio from the image.
+    static func edgeToEdgeScaleBoost(hDeg: CGFloat, vDeg: CGFloat) -> CGFloat {
+        let transitionEnd = SkewTuning.transitionEndDegrees
+        let absH = abs(hDeg)
+        let absV = abs(vDeg)
+        let hActivity = min(absH / SkewTuning.axisActivityRampDegrees, 1.0)
+        let vActivity = min(absV / SkewTuning.axisActivityRampDegrees, 1.0)
+
+        // Each axis's boost is dampened by the other axis's activity.
+        let hEdgeFade = max(1 - absH / transitionEnd, 0) * (1 - vActivity)
+        let vEdgeFade = max(1 - absV / transitionEnd, 0) * (1 - hActivity)
+
+        // Scale the boost by how much skew there is (normalized to 0-1
+        // within the edge-to-edge range).
+        let hBoostIntensity = min(absH / SkewTuning.scaleBoostRampDegrees, 1.0) * hEdgeFade
+        let vBoostIntensity = min(absV / SkewTuning.scaleBoostRampDegrees, 1.0) * vEdgeFade
+        return 1.0 + SkewTuning.maxScaleBoost * max(hBoostIntensity, vBoostIntensity)
+    }
+}

--- a/Tests/MantisTests/SkewPositioningTests.swift
+++ b/Tests/MantisTests/SkewPositioningTests.swift
@@ -1,0 +1,246 @@
+//
+//  SkewPositioningTests.swift
+//  MantisTests
+//
+//  Pins the pure skew-positioning math extracted from CropView+Skew.swift.
+//  These functions have no UIKit/view dependencies, so their behavior can be
+//  fixed exactly — which matters because the live skew preview keeps three
+//  sources of truth (view-model angle, sublayerTransform, contentInset) in
+//  manual sync, making regressions here easy to introduce and hard to spot.
+//
+//  Containment/shift tests use CATransform3DIdentity, under which
+//  `projectDisplacement` is the identity map and every corner is "in front of
+//  the camera", reducing the perspective containment test to a plain
+//  point-in-rectangle check with hand-computable expectations.
+//
+
+import XCTest
+@testable import Mantis
+
+final class SkewPositioningTests: XCTestCase {
+
+    private typealias Sut = SkewPositioning
+    private let accuracy: CGFloat = 1e-6
+
+    // MARK: - Value type accessors
+
+    func testSkewShiftsCenteredShifts() {
+        let shifts = SkewShifts(top: 10, left: 20, bottom: 30, right: 40)
+        XCTAssertEqual(shifts.centeredShiftX, (40 - 20) / 2, accuracy: accuracy)
+        XCTAssertEqual(shifts.centeredShiftY, (30 - 10) / 2, accuracy: accuracy)
+    }
+
+    func testContextCenterOffset() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100))
+        // midX - boundsW/2 = 100 - 50, midY - boundsH/2 = 100 - 50
+        XCTAssertEqual(ctx.centerOffset.x, 50, accuracy: accuracy)
+        XCTAssertEqual(ctx.centerOffset.y, 50, accuracy: accuracy)
+    }
+
+    func testContextImageCornerDisplacements() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100))
+        let corners = ctx.imageCornerDisplacements(from: CGPoint(x: 100, y: 100))
+        XCTAssertEqual(corners, [
+            CGPoint(x: -100, y: -100),  // TL
+            CGPoint(x: 100, y: -100),   // TR
+            CGPoint(x: 100, y: 100),    // BR
+            CGPoint(x: -100, y: 100)    // BL
+        ])
+    }
+
+    // MARK: - edgeToEdgeShift blend
+
+    func testEdgeToEdgeShiftZeroDegreesReturnsCentered() {
+        let result = Sut.edgeToEdgeShift(deg: 0, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                         centeredShift: 10, rotationDampen: 1, crossAxisActivity: 0)
+        XCTAssertEqual(result, 10, accuracy: accuracy)
+    }
+
+    func testEdgeToEdgeShiftBelowTransitionUsesEdgeAligned() {
+        // deg 4 < transitionStart(8), full dampen -> pure edge alignment.
+        let pos = Sut.edgeToEdgeShift(deg: 4, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                      centeredShift: 10, rotationDampen: 1, crossAxisActivity: 0)
+        XCTAssertEqual(pos, 40, accuracy: accuracy)
+        let neg = Sut.edgeToEdgeShift(deg: -4, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                      centeredShift: 10, rotationDampen: 1, crossAxisActivity: 0)
+        XCTAssertEqual(neg, -20, accuracy: accuracy)
+    }
+
+    func testEdgeToEdgeShiftAtOrAboveTransitionEndReturnsCentered() {
+        for deg in [SkewTuning.transitionEndDegrees, 20] as [CGFloat] {
+            let result = Sut.edgeToEdgeShift(deg: deg, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                             centeredShift: 10, rotationDampen: 1, crossAxisActivity: 0)
+            XCTAssertEqual(result, 10, accuracy: accuracy, "deg=\(deg) should be fully inscribed")
+        }
+    }
+
+    func testEdgeToEdgeShiftMidTransitionBlendsHalfway() {
+        // deg 10 -> blend = (10-8)/(12-8) = 0.5; edgeAligned=40, centered=10 -> 25.
+        let result = Sut.edgeToEdgeShift(deg: 10, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                         centeredShift: 10, rotationDampen: 1, crossAxisActivity: 0)
+        XCTAssertEqual(result, 25, accuracy: accuracy)
+    }
+
+    func testEdgeToEdgeShiftFullCrossAxisActivityCollapsesToCentered() {
+        let result = Sut.edgeToEdgeShift(deg: 4, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                         centeredShift: 10, rotationDampen: 1, crossAxisActivity: 1)
+        XCTAssertEqual(result, 10, accuracy: accuracy)
+    }
+
+    func testEdgeToEdgeShiftZeroRotationDampenCollapsesToCentered() {
+        let result = Sut.edgeToEdgeShift(deg: 4, positiveEdgeShift: 40, negativeEdgeShift: -20,
+                                         centeredShift: 10, rotationDampen: 0, crossAxisActivity: 0)
+        XCTAssertEqual(result, 10, accuracy: accuracy)
+    }
+
+    // MARK: - edgeToEdgeScaleBoost
+
+    func testScaleBoostZeroSkewIsUnity() {
+        XCTAssertEqual(Sut.edgeToEdgeScaleBoost(hDeg: 0, vDeg: 0), 1.0, accuracy: accuracy)
+    }
+
+    func testScaleBoostAtOrAboveTransitionEndIsUnity() {
+        XCTAssertEqual(Sut.edgeToEdgeScaleBoost(hDeg: 12, vDeg: 0), 1.0, accuracy: accuracy)
+        XCTAssertEqual(Sut.edgeToEdgeScaleBoost(hDeg: 0, vDeg: 20), 1.0, accuracy: accuracy)
+    }
+
+    func testScaleBoostSingleAxisKnownValue() {
+        // hDeg=10: hActivity=1, hEdgeFade=(1-10/12)=1/6, intensity=min(10/10,1)*1/6=1/6.
+        // boost = 1 + 0.04 * (1/6).
+        let expected = 1.0 + 0.04 * (1.0 / 6.0)
+        XCTAssertEqual(Sut.edgeToEdgeScaleBoost(hDeg: 10, vDeg: 0), expected, accuracy: accuracy)
+    }
+
+    func testScaleBoostIsAxisSymmetric() {
+        XCTAssertEqual(Sut.edgeToEdgeScaleBoost(hDeg: 5, vDeg: 0),
+                       Sut.edgeToEdgeScaleBoost(hDeg: 0, vDeg: 5), accuracy: accuracy)
+    }
+
+    func testScaleBoostNeverBelowUnity() {
+        for hDeg in stride(from: CGFloat(0), through: 30, by: 1.5) {
+            for vDeg in stride(from: CGFloat(0), through: 30, by: 1.5) {
+                XCTAssertGreaterThanOrEqual(Sut.edgeToEdgeScaleBoost(hDeg: hDeg, vDeg: vDeg), 1.0)
+            }
+        }
+    }
+
+    // MARK: - contentInset / lockedCenterInset
+
+    func testContentInsetKnownValues() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              contentSize: CGSize(width: 300, height: 300))
+        let shifts = SkewShifts(top: 10, left: 20, bottom: 30, right: 40)
+        let inset = Sut.contentInset(shifts: shifts, context: ctx)
+        // center = (50, 50); contentH-boundsH = contentW-boundsW = 200.
+        XCTAssertEqual(inset.top, 10 - 50, accuracy: accuracy)
+        XCTAssertEqual(inset.left, 20 - 50, accuracy: accuracy)
+        XCTAssertEqual(inset.bottom, (50 + 30) - 200, accuracy: accuracy)
+        XCTAssertEqual(inset.right, (50 + 40) - 200, accuracy: accuracy)
+    }
+
+    func testLockedCenterInsetKnownValues() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              contentSize: CGSize(width: 300, height: 300))
+        let inset = Sut.lockedCenterInset(context: ctx)
+        XCTAssertEqual(inset.top, -50, accuracy: accuracy)
+        XCTAssertEqual(inset.left, -50, accuracy: accuracy)
+        XCTAssertEqual(inset.bottom, 50 - 200, accuracy: accuracy)
+        XCTAssertEqual(inset.right, 50 - 200, accuracy: accuracy)
+    }
+
+    // MARK: - optimalOffset
+
+    func testOptimalOffsetNonMatchingAspectRatioIsCentered() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100))
+        let shifts = SkewShifts(top: 10, left: 20, bottom: 30, right: 40)
+        let offset = Sut.optimalOffset(hDeg: 5, vDeg: 5, shifts: shifts, context: ctx,
+                                       matchesAspectRatio: false, totalRadians: 0)
+        // center (50,50) + centered (10,10).
+        XCTAssertEqual(offset.x, 60, accuracy: accuracy)
+        XCTAssertEqual(offset.y, 60, accuracy: accuracy)
+    }
+
+    func testOptimalOffsetMatchingZeroSkewEqualsCentered() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100))
+        let shifts = SkewShifts(top: 10, left: 20, bottom: 30, right: 40)
+        let offset = Sut.optimalOffset(hDeg: 0, vDeg: 0, shifts: shifts, context: ctx,
+                                       matchesAspectRatio: true, totalRadians: 0)
+        XCTAssertEqual(offset.x, 60, accuracy: accuracy)
+        XCTAssertEqual(offset.y, 60, accuracy: accuracy)
+    }
+
+    func testOptimalOffsetMatchingSmallHorizontalSkewAlignsEdge() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100))
+        let shifts = SkewShifts(top: 10, left: 20, bottom: 30, right: 40)
+        // hDeg=4 (<8, no rotation, no cross-axis) -> X aligns to right edge (40).
+        // vDeg=0 -> Y stays centered (10).
+        let offset = Sut.optimalOffset(hDeg: 4, vDeg: 0, shifts: shifts, context: ctx,
+                                       matchesAspectRatio: true, totalRadians: 0)
+        XCTAssertEqual(offset.x, 50 + 40, accuracy: accuracy)
+        XCTAssertEqual(offset.y, 50 + 10, accuracy: accuracy)
+    }
+
+    // MARK: - Containment & shift search (identity transform)
+
+    func testIsCropBoxInsideCenteredSmallBoxIsInside() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              cropCorners: squareCorners(halfSize: 25))
+        XCTAssertTrue(Sut.isCropBoxInside(shiftX: 0, shiftY: 0, context: ctx))
+    }
+
+    func testIsCropBoxInsideOversizedBoxIsOutside() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              cropCorners: squareCorners(halfSize: 150))
+        XCTAssertFalse(Sut.isCropBoxInside(shiftX: 0, shiftY: 0, context: ctx))
+    }
+
+    func testMaxShiftRightMatchesGeometry() {
+        // 200x200 image, 50x50 crop (half 25) centered. Shifting the anchor in
+        // +x keeps the box inside until the image's right edge reaches the box:
+        // max shift = imageHalf(100) - cropHalf(25) = 75.
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              cropCorners: squareCorners(halfSize: 25))
+        let shift = Sut.maxShift(dirX: 1, dirY: 0, context: ctx)
+        XCTAssertEqual(shift, 75, accuracy: 0.05)
+    }
+
+    func testMaxShiftsSymmetricForCenteredSquare() {
+        let ctx = makeContext(imageFrame: CGRect(x: 0, y: 0, width: 200, height: 200),
+                              boundsSize: CGSize(width: 100, height: 100),
+                              cropCorners: squareCorners(halfSize: 25))
+        let shifts = Sut.maxShifts(context: ctx)
+        XCTAssertEqual(shifts.top, 75, accuracy: 0.05)
+        XCTAssertEqual(shifts.bottom, 75, accuracy: 0.05)
+        XCTAssertEqual(shifts.left, 75, accuracy: 0.05)
+        XCTAssertEqual(shifts.right, 75, accuracy: 0.05)
+    }
+
+    // MARK: - Helpers
+
+    private func makeContext(imageFrame: CGRect,
+                             boundsSize: CGSize,
+                             contentSize: CGSize = CGSize(width: 300, height: 300),
+                             cropCorners: [CGPoint] = [],
+                             transform: CATransform3D = CATransform3DIdentity) -> SkewInsetContext {
+        SkewInsetContext(imageFrame: imageFrame,
+                         boundsSize: boundsSize,
+                         contentSize: contentSize,
+                         cropCorners: cropCorners,
+                         transform: transform)
+    }
+
+    private func squareCorners(halfSize half: CGFloat) -> [CGPoint] {
+        [CGPoint(x: -half, y: -half), CGPoint(x: half, y: -half),
+         CGPoint(x: half, y: half), CGPoint(x: -half, y: half)]
+    }
+}


### PR DESCRIPTION
Follow-up to #531. That PR was squash-merged before this commit landed, so the extraction never reached `master` — this re-applies it (cherry-picked cleanly onto the current `master`, which already has #530 and #531).

## What

`CropView+Skew.swift` mixed UIKit-coupled orchestration with pure geometry. This moves the stateless math into a new **`SkewPositioning`** component — containment tests, cardinal-direction shift search, `contentInset` / `lockedCenterInset` conversion, the edge-to-edge blend, the two-phase optimal-offset, and the scale boost — operating on the now top-level pure value types `SkewInsetContext` / `SkewShifts`. `SkewTuning` (added in #531) moves alongside.

`CropView+Skew.swift` keeps only view-coupled work (reading the scroll view / view model, applying `sublayerTransform` / `contentInset` / `contentOffset`); call sites delegate to `SkewPositioning`, passing view-derived inputs (`matchesAspectRatio`, `totalRadians`) as parameters. **The moved bodies are verbatim — behavior is unchanged.** CropView+Skew.swift drops from 716 → 449 lines.

## Tests

Added **`SkewPositioningTests` (23 cases)** pinning the extracted math: the blend at the 8/12 transition boundaries and dampening, the scale-boost curve and symmetry, inset/offset arithmetic, and containment + binary-search shift distances under an identity transform (hand-computable expectations).

## Validation

- `xcodebuild test -scheme Mantis-Package … IPHONEOS_DEPLOYMENT_TARGET=17.0` (mirrors CI) → **148 tests, 0 failures** (was 125; +23 new)

## ⚠️ Unrelated pre-existing issue spotted

While verifying at the real `IPHONEOS_DEPLOYMENT_TARGET=15.0`, `SlideRuler.swift:56` fails to compile: it calls `registerForTraitChanges` / `systemTraitsAffectingColorAppearance` (iOS 17+) with no `#available` guard, while the package/podspec declare **iOS 15**. CI masks this by overriding the target to `17.0`, so `master` is green — but a real consumer building at iOS 15 would break. Not touched here; worth a separate fix (guard with `if #available(iOS 17, *)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved perspective-skew crop positioning for more accurate preview placement and smoother offset behavior.
  * Added better handling for edge-to-edge and center-locked crop alignment across different skew angles.

* **Bug Fixes**
  * Increased containment checks to help keep the crop box within the visible image area during skew adjustments.
  * Refined pan limits and offset calculations to reduce unexpected jumps and invalid positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->