### PR TITLE
fix: guard iOS 17 trait-change API for the declared iOS 15 minimum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,13 @@ jobs:
             else
                FORMATTER="cat"
             fi
+            # Build at the package's declared minimum (iOS 15) so CI catches
+            # any use of newer APIs that lacks an availability guard. Do NOT
+            # override IPHONEOS_DEPLOYMENT_TARGET here — that masks such breaks.
             xcodebuild test \
                -scheme Mantis-Package \
                -destination "platform=iOS Simulator,name=iPhone 16" \
                -skipPackagePluginValidation \
-               IPHONEOS_DEPLOYMENT_TARGET=17.0 \
                CODE_SIGNING_ALLOWED=NO \
                | "$FORMATTER"
            env:

--- a/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
+++ b/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
@@ -27,11 +27,27 @@ final class CropMaskVisualEffectView: UIVisualEffectView, CropMaskProtocol {
         self.effectType = effectType
         self.translucencyEffect = translucencyEffect
         self.backgroundColor = backgroundColor
-        registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if case .blurSystem = self.effectType,
-               self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                self.applyBlurSystemEffect()
+        // iOS 17+ uses the modern trait-change registration; earlier versions
+        // (the library supports iOS 15) fall back to `traitCollectionDidChange`.
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
+                if case .blurSystem = self.effectType,
+                   self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                    self.applyBlurSystemEffect()
+                }
             }
+        }
+    }
+
+    // iOS 16 and earlier: `registerForTraitChanges` is unavailable, so use the
+    // (pre-iOS-17) trait-change hook. On iOS 17+ the registration above handles it.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard #unavailable(iOS 17.0) else { return }
+        if case .blurSystem = effectType,
+           let previousTraitCollection,
+           traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyBlurSystemEffect()
         }
     }
         

--- a/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
+++ b/Sources/Mantis/MaskBackground/CropVisualEffectView.swift
@@ -30,9 +30,9 @@ final class CropMaskVisualEffectView: UIVisualEffectView, CropMaskProtocol {
         // iOS 17+ uses the modern trait-change registration; earlier versions
         // (the library supports iOS 15) fall back to `traitCollectionDidChange`.
         if #available(iOS 17.0, *) {
-            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previous: UITraitCollection) in
                 if case .blurSystem = self.effectType,
-                   self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                   self.traitCollection.hasDifferentColorAppearance(comparedTo: previous) {
                     self.applyBlurSystemEffect()
                 }
             }

--- a/Sources/Mantis/RotationDial/SlideDial/SlideDialTypeButton.swift
+++ b/Sources/Mantis/RotationDial/SlideDial/SlideDialTypeButton.swift
@@ -42,16 +42,36 @@ final class SlideDialTypeButton: UIView {
         setupLayers()
         setupSubviews()
         updateAppearance()
-        registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                self.ringLayer.fillColor = self.config.buttonFillColor.cgColor
-                self.updateAppearance()
+        // iOS 17+ uses the modern trait-change registration; earlier versions
+        // (the library supports iOS 15) fall back to `traitCollectionDidChange`.
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
+                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                    self.applyColorsForCurrentTraitCollection()
+                }
             }
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    // iOS 16 and earlier: `registerForTraitChanges` is unavailable, so use the
+    // (pre-iOS-17) trait-change hook. On iOS 17+ the registration above handles it.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard #unavailable(iOS 17.0) else { return }
+        if let previousTraitCollection,
+           traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColorsForCurrentTraitCollection()
+        }
+    }
+
+    /// Reapplies colors on a light/dark appearance change.
+    private func applyColorsForCurrentTraitCollection() {
+        ringLayer.fillColor = config.buttonFillColor.cgColor
+        updateAppearance()
     }
     
     override func layoutSubviews() {

--- a/Sources/Mantis/RotationDial/SlideDial/SlideDialTypeButton.swift
+++ b/Sources/Mantis/RotationDial/SlideDial/SlideDialTypeButton.swift
@@ -45,8 +45,8 @@ final class SlideDialTypeButton: UIView {
         // iOS 17+ uses the modern trait-change registration; earlier versions
         // (the library supports iOS 15) fall back to `traitCollectionDidChange`.
         if #available(iOS 17.0, *) {
-            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
-                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previous: UITraitCollection) in
+                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previous) {
                     self.applyColorsForCurrentTraitCollection()
                 }
             }

--- a/Sources/Mantis/RotationDial/SlideDial/SlideRuler.swift
+++ b/Sources/Mantis/RotationDial/SlideDial/SlideRuler.swift
@@ -53,20 +53,43 @@ final class SlideRuler: UIView {
         
         positionInfoHelper = BilateralTypeSlideRulerPositionHelper()
         positionInfoHelper.slideRuler = self
-        registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
-            if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
-                self.pointer.backgroundColor = self.config.pointerColor.cgColor
-                self.centralDot.fillColor = self.config.centralDotColor.cgColor
-                let newScaleColor = self.config.scaleColor.cgColor
-                let newMajorScaleColor = self.config.majorScaleColor.cgColor
-                self.scaleBars.forEach { $0.backgroundColor = newScaleColor }
-                self.majorScaleBars.forEach { $0.backgroundColor = newMajorScaleColor }
+        // iOS 17+ uses the modern trait-change registration. Earlier versions
+        // (the library supports iOS 15) fall back to `traitCollectionDidChange`
+        // below, since `registerForTraitChanges` is unavailable before iOS 17.
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
+                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+                    self.applyColorsForCurrentTraitCollection()
+                }
             }
         }
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError()
+    }
+
+    // iOS 16 and earlier: `registerForTraitChanges` is unavailable, so use the
+    // (pre-iOS-17) trait-change hook to refresh colors on a light/dark switch.
+    // On iOS 17+ the registration above handles this instead.
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard #unavailable(iOS 17.0) else { return }
+        if let previousTraitCollection,
+           traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            applyColorsForCurrentTraitCollection()
+        }
+    }
+
+    /// Reapplies the configured colors to all layers. Called on a color-appearance
+    /// (light/dark) trait change so the ruler re-renders in the new appearance.
+    private func applyColorsForCurrentTraitCollection() {
+        pointer.backgroundColor = config.pointerColor.cgColor
+        centralDot.fillColor = config.centralDotColor.cgColor
+        let newScaleColor = config.scaleColor.cgColor
+        let newMajorScaleColor = config.majorScaleColor.cgColor
+        scaleBars.forEach { $0.backgroundColor = newScaleColor }
+        majorScaleBars.forEach { $0.backgroundColor = newMajorScaleColor }
     }
     
     func setupUI() {

--- a/Sources/Mantis/RotationDial/SlideDial/SlideRuler.swift
+++ b/Sources/Mantis/RotationDial/SlideDial/SlideRuler.swift
@@ -57,8 +57,8 @@ final class SlideRuler: UIView {
         // (the library supports iOS 15) fall back to `traitCollectionDidChange`
         // below, since `registerForTraitChanges` is unavailable before iOS 17.
         if #available(iOS 17.0, *) {
-            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previousTraitCollection: UITraitCollection) in
-                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            registerForTraitChanges(UITraitCollection.systemTraitsAffectingColorAppearance) { (self: Self, previous: UITraitCollection) in
+                if self.traitCollection.hasDifferentColorAppearance(comparedTo: previous) {
                     self.applyColorsForCurrentTraitCollection()
                 }
             }


### PR DESCRIPTION
## Problem

`registerForTraitChanges(_:handler:)` and `UITraitCollection.systemTraitsAffectingColorAppearance` are **iOS 17+**, but the package and podspec declare **iOS 15**. Three views called them with no availability guard:

- `SlideRuler`
- `SlideDialTypeButton`
- `CropMaskVisualEffectView`

So a consumer building at the real iOS 15 deployment target fails to compile:

```
error: 'registerForTraitChanges(_:handler:)' is only available in iOS 17.0 or newer
```

`master` stayed green only because the CI step overrode `IPHONEOS_DEPLOYMENT_TARGET=17.0`, masking the break. (Surfaced while verifying #532 at the real target.)

## Fix

1. **Source (3 files):** gate each registration behind `if #available(iOS 17.0, *)`, and add a `traitCollectionDidChange` fallback guarded with `#unavailable(iOS 17.0)` (so iOS 17+ doesn't double-handle) that reapplies colors / the blur effect on a light–dark switch. Per-view refresh logic is factored into a small helper shared by both paths. Behavior is unchanged on iOS 17+; iOS 15–16 now get the same dark-mode refresh.
2. **CI:** drop the `IPHONEOS_DEPLOYMENT_TARGET=17.0` override so the build runs at the package's real minimum and catches this class of regression going forward.

## Validation

- `xcodebuild build -scheme Mantis` at **`IPHONEOS_DEPLOYMENT_TARGET=15.0`** → **BUILD SUCCEEDED** (previously failed)
- CI command **without** the override (real iOS 15 target) → **125 tests, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved light/dark mode handling for iOS 16 and earlier, including blur-based visual effects and dial/ruler color refreshes.
  * Updated multiple UI components to react more reliably to system appearance changes by using appropriate iOS-version behavior.
* **CI / Tests**
  * Adjusted the CI `xcodebuild test` setup so it builds against the package’s declared minimum iOS deployment target, improving detection of missing availability guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->