### PR TITLE
refactor!: remove deprecated CropViewConfig props; slim public CropInfo (next major)

### DIFF
--- a/Sources/Mantis/CropData.swift
+++ b/Sources/Mantis/CropData.swift
@@ -132,20 +132,14 @@ public struct CropInfo: Sendable {
     public var cropRegion: CropRegion
     public var horizontalSkewDegrees: CGFloat
     public var verticalSkewDegrees: CGFloat
-    /// The actual CATransform3D sublayerTransform used in the preview for perspective skew.
-    /// Includes perspective rotation, centering, and compensating scale.
-    /// Set to CATransform3DIdentity when no skew is applied.
-    public var skewSublayerTransform: CATransform3D
-    /// The scroll view's content offset during crop (for reconstructing the view hierarchy)
-    public var scrollContentOffset: CGPoint
-    /// The scroll view's visible bounds size during crop
-    public var scrollBoundsSize: CGSize
-    /// The image container's frame in scroll content coordinates during crop
-    public var imageContainerFrame: CGRect
-    /// The actual 2D transform of the scroll view (rotation + flip), used by the
-    /// perspective crop path so it can invert the exact transform without
-    /// reconstructing it from decomposed rotation / scale values.
-    public var scrollViewTransform: CGAffineTransform
+
+    /// View-hierarchy state captured at crop time, needed only to reconstruct
+    /// and invert the exact on-screen transform in the perspective / CIImage
+    /// crop paths. Populated by `CropView.getCropInfo()`; `nil` for a `CropInfo`
+    /// a caller builds directly (those crop paths then return `nil` rather than
+    /// producing a wrong result). Kept out of the public API so the public
+    /// surface carries only semantic crop parameters.
+    var viewReconstruction: ViewReconstruction?
 
     public init(
         translation: CGPoint,
@@ -156,12 +150,7 @@ public struct CropInfo: Sendable {
         imageViewSize: CGSize,
         cropRegion: CropRegion,
         horizontalSkewDegrees: CGFloat = 0,
-        verticalSkewDegrees: CGFloat = 0,
-        skewSublayerTransform: CATransform3D = CATransform3DIdentity,
-        scrollContentOffset: CGPoint = .zero,
-        scrollBoundsSize: CGSize = .zero,
-        imageContainerFrame: CGRect = .zero,
-        scrollViewTransform: CGAffineTransform = .identity
+        verticalSkewDegrees: CGFloat = 0
     ) {
         self.translation = translation
         self.rotation = rotation
@@ -172,11 +161,29 @@ public struct CropInfo: Sendable {
         self.cropRegion = cropRegion
         self.horizontalSkewDegrees = horizontalSkewDegrees
         self.verticalSkewDegrees = verticalSkewDegrees
-        self.skewSublayerTransform = skewSublayerTransform
-        self.scrollContentOffset = scrollContentOffset
-        self.scrollBoundsSize = scrollBoundsSize
-        self.imageContainerFrame = imageContainerFrame
-        self.scrollViewTransform = scrollViewTransform
+        self.viewReconstruction = nil
+    }
+}
+
+extension CropInfo {
+    /// Captured scroll-view / layer state that lets the perspective and
+    /// large-image (CIImage) crop paths rebuild and invert the exact transform
+    /// used on screen. Internal — not part of the public crop API.
+    struct ViewReconstruction: Sendable {
+        /// The CATransform3D sublayerTransform used in the preview for perspective
+        /// skew (perspective rotation, centering, compensating scale). Identity
+        /// when no skew is applied.
+        var skewSublayerTransform: CATransform3D
+        /// The scroll view's content offset during crop.
+        var scrollContentOffset: CGPoint
+        /// The scroll view's visible bounds size during crop.
+        var scrollBoundsSize: CGSize
+        /// The image container's frame in scroll content coordinates during crop.
+        var imageContainerFrame: CGRect
+        /// The scroll view's actual 2D transform (rotation + flip), inverted by the
+        /// perspective crop path instead of reconstructing it from decomposed
+        /// rotation / scale values.
+        var scrollViewTransform: CGAffineTransform
     }
 }
 

--- a/Sources/Mantis/CropView/CropView+Crop.swift
+++ b/Sources/Mantis/CropView/CropView+Crop.swift
@@ -169,7 +169,7 @@ extension CropView {
         let cropRegion = imageContainer.getCropRegion(withCropBoxFrame: viewModel.cropBoxFrame,
                                                       cropView: self)
         
-        return CropInfo(
+        var cropInfo = CropInfo(
             translation: translation,
             rotation: totalRadians,
             scaleX: scaleX,
@@ -178,13 +178,16 @@ extension CropView {
             imageViewSize: imageContainer.bounds.size,
             cropRegion: cropRegion,
             horizontalSkewDegrees: viewModel.horizontalSkewDegrees,
-            verticalSkewDegrees: viewModel.verticalSkewDegrees,
+            verticalSkewDegrees: viewModel.verticalSkewDegrees
+        )
+        cropInfo.viewReconstruction = CropInfo.ViewReconstruction(
             skewSublayerTransform: cropWorkbenchView.layer.sublayerTransform,
             scrollContentOffset: cropWorkbenchView.contentOffset,
             scrollBoundsSize: cropWorkbenchView.bounds.size,
             imageContainerFrame: imageContainer.frame,
             scrollViewTransform: cropWorkbenchView.transform
         )
+        return cropInfo
     }
     
     func getExpectedCropImageSize() -> CGSize {

--- a/Sources/Mantis/CropViewConfig.swift
+++ b/Sources/Mantis/CropViewConfig.swift
@@ -1,39 +1,6 @@
 import UIKit
 
 public struct CropViewConfig {
-    /**
-        This value is for how easy to drag crop box. The bigger, the easier.
-     */
-    @available(*, deprecated, message: "Use cropAuxiliaryIndicatorStyle.cropBoxHotAreaUnit instead")
-    public var cropBoxHotAreaUnit: CGFloat {
-        get {
-            cropAuxiliaryIndicatorConfig.cropBoxHotAreaUnit
-        }
-        set {
-            cropAuxiliaryIndicatorConfig.cropBoxHotAreaUnit = newValue
-        }
-    }
-    
-    @available(*, deprecated, message: "Use cropAuxiliaryIndicatorStyle.disableCropBoxDeformation instead")
-    public var disableCropBoxDeformation: Bool {
-        get {
-            cropAuxiliaryIndicatorConfig.disableCropBoxDeformation
-        }
-        set {
-            cropAuxiliaryIndicatorConfig.disableCropBoxDeformation = newValue
-        }
-    }
-    
-    @available(*, deprecated, message: "Use cropAuxiliaryIndicatorConfig.style instead")
-    public var cropAuxiliaryIndicatorStyle: CropAuxiliaryIndicatorStyleType {
-        get {
-            cropAuxiliaryIndicatorConfig.style
-        }
-        set {
-            cropAuxiliaryIndicatorConfig.style = newValue
-        }
-    }
-    
     public var cropAuxiliaryIndicatorConfig = CropAuxiliaryIndicatorConfig()
     
     public var cropShapeType: CropShapeType = .rect
@@ -66,13 +33,6 @@ public struct CropViewConfig {
     }
     
     public var maximumZoomScale: CGFloat = 15
-    
-    @available(*, deprecated, message: "Use showAttachedRotationControlView instead")
-    public var showRotationDial = true {
-        didSet {
-            showAttachedRotationControlView = showRotationDial
-        }
-    }
     
     public var showAttachedRotationControlView = true
     

--- a/Sources/Mantis/Extensions/UIImageExtensions.swift
+++ b/Sources/Mantis/Extensions/UIImageExtensions.swift
@@ -164,10 +164,11 @@ extension UIImage {
         guard outputWidth > 0 && outputHeight > 0,
               outputWidth.isFinite && outputHeight.isFinite else { return nil }
 
-        let scrollBoundsSize = cropInfo.scrollBoundsSize
-        let scrollContentOffset = cropInfo.scrollContentOffset
-        let imgContainerFrame = cropInfo.imageContainerFrame
-        let sublayerTransform = cropInfo.skewSublayerTransform
+        guard let reconstruction = cropInfo.viewReconstruction else { return nil }
+        let scrollBoundsSize = reconstruction.scrollBoundsSize
+        let scrollContentOffset = reconstruction.scrollContentOffset
+        let imgContainerFrame = reconstruction.imageContainerFrame
+        let sublayerTransform = reconstruction.skewSublayerTransform
 
         guard imgContainerFrame.size.width > 0, imgContainerFrame.size.height > 0,
               imgContainerFrame.size.width.isFinite, imgContainerFrame.size.height.isFinite,
@@ -194,7 +195,7 @@ extension UIImage {
         // values. The flip() method builds the transform via
         //   R(rot) · S(flip) · R(extra)
         // which does not decompose cleanly into a single rotation + scale pair.
-        let inverseTransform = cropInfo.scrollViewTransform.inverted()
+        let inverseTransform = reconstruction.scrollViewTransform.inverted()
 
         let contentCorners = screenCorners.map { point -> CGPoint in
             point.applying(inverseTransform)
@@ -421,10 +422,11 @@ extension UIImage {
 
         // Compute source pixel quad from crop box corners + transforms
         // (same coordinate math as cropWithPerspective)
-        let scrollBoundsSize = cropInfo.scrollBoundsSize
-        let scrollContentOffset = cropInfo.scrollContentOffset
-        let imgContainerFrame = cropInfo.imageContainerFrame
-        let sublayerTransform = cropInfo.skewSublayerTransform
+        guard let reconstruction = cropInfo.viewReconstruction else { return nil }
+        let scrollBoundsSize = reconstruction.scrollBoundsSize
+        let scrollContentOffset = reconstruction.scrollContentOffset
+        let imgContainerFrame = reconstruction.imageContainerFrame
+        let sublayerTransform = reconstruction.skewSublayerTransform
 
         guard imgContainerFrame.size.width > 0, imgContainerFrame.size.height > 0,
               imgContainerFrame.size.width.isFinite, imgContainerFrame.size.height.isFinite,
@@ -442,7 +444,7 @@ extension UIImage {
             CGPoint(x: -halfCropW, y: halfCropH)
         ]
 
-        let inverseTransform = cropInfo.scrollViewTransform.inverted()
+        let inverseTransform = reconstruction.scrollViewTransform.inverted()
         let contentCorners = screenCorners.map { $0.applying(inverseTransform) }
         let sourceContentDisplacements = contentCorners.map {
             inverseProjectDisplacement($0, through: sublayerTransform)

--- a/Tests/MantisTests/CICropEquivalenceTests.swift
+++ b/Tests/MantisTests/CICropEquivalenceTests.swift
@@ -64,7 +64,7 @@ final class CICropEquivalenceTests: XCTestCase {
         // translation = image container center - crop box center (both in content coords)
         let containerCenter = CGPoint(x: viewSize.width * zoom / 2, y: viewSize.height * zoom / 2)
         let cropBoxCenter = CGPoint(x: contentOffset.x + cropSize.width / 2, y: contentOffset.y + cropSize.height / 2)
-        return CropInfo(
+        var info = CropInfo(
             translation: CGPoint(x: containerCenter.x - cropBoxCenter.x, y: containerCenter.y - cropBoxCenter.y),
             rotation: 0,
             scaleX: zoom,
@@ -73,13 +73,16 @@ final class CICropEquivalenceTests: XCTestCase {
             imageViewSize: viewSize,
             cropRegion: CropRegion(topLeft: .zero, topRight: .zero, bottomLeft: .zero, bottomRight: .zero),
             horizontalSkewDegrees: 0,
-            verticalSkewDegrees: 0,
+            verticalSkewDegrees: 0
+        )
+        info.viewReconstruction = CropInfo.ViewReconstruction(
             skewSublayerTransform: CATransform3DIdentity,
             scrollContentOffset: contentOffset,
             scrollBoundsSize: cropSize,
             imageContainerFrame: CGRect(origin: .zero, size: CGSize(width: viewSize.width * zoom, height: viewSize.height * zoom)),
             scrollViewTransform: .identity
         )
+        return info
     }
 
     private func assertSameCrop(_ image: UIImage, _ cropInfo: CropInfo,
@@ -158,7 +161,7 @@ final class CICropEquivalenceTests: XCTestCase {
         XCTAssertNil(image.cropWithCIImage(by: cropInfo), "zero zoom scale must not crash or return garbage")
 
         cropInfo.scaleX = 1
-        cropInfo.imageContainerFrame = CGRect(x: CGFloat.nan, y: 0, width: 50, height: 40)
+        cropInfo.viewReconstruction?.imageContainerFrame = CGRect(x: CGFloat.nan, y: 0, width: 50, height: 40)
         XCTAssertNil(image.cropWithCIImage(by: cropInfo), "NaN container frame must not crash or return garbage")
     }
 

--- a/Tests/MantisTests/UIImageExtensionsTests.swift
+++ b/Tests/MantisTests/UIImageExtensionsTests.swift
@@ -180,7 +180,7 @@ final class UIImageExtensionsTests: XCTestCase {
         let containerCenter = CGPoint(x: viewSize.width * zoom / 2, y: viewSize.height * zoom / 2)
         let cropBoxCenter = CGPoint(x: contentOffset.x + cropSize.width / 2,
                                     y: contentOffset.y + cropSize.height / 2)
-        return CropInfo(
+        var info = CropInfo(
             translation: CGPoint(x: containerCenter.x - cropBoxCenter.x, y: containerCenter.y - cropBoxCenter.y),
             rotation: 0,
             scaleX: zoom,
@@ -189,7 +189,9 @@ final class UIImageExtensionsTests: XCTestCase {
             imageViewSize: viewSize,
             cropRegion: CropRegion(topLeft: .zero, topRight: .zero, bottomLeft: .zero, bottomRight: .zero),
             horizontalSkewDegrees: horizontalSkewDegrees,
-            verticalSkewDegrees: 0,
+            verticalSkewDegrees: 0
+        )
+        info.viewReconstruction = CropInfo.ViewReconstruction(
             skewSublayerTransform: CATransform3DIdentity, // identity => no actual warp
             scrollContentOffset: contentOffset,
             scrollBoundsSize: cropSize,
@@ -197,6 +199,7 @@ final class UIImageExtensionsTests: XCTestCase {
                                         size: CGSize(width: viewSize.width * zoom, height: viewSize.height * zoom)),
             scrollViewTransform: .identity
         )
+        return info
     }
 
     func testCropWithPerspectiveIdentityWarpMatchesLegacyCrop() {


### PR DESCRIPTION
> **Draft — targeted at the next major version.** Both changes are breaking, so this should ship in a `x.0.0` release, not be merged into a minor. Opening as a draft so the design can be reviewed ahead of time.

## 1. Remove 4 deprecated `CropViewConfig` forwarding properties

| Removed | Replacement |
|---|---|
| `cropBoxHotAreaUnit` | `cropAuxiliaryIndicatorConfig.cropBoxHotAreaUnit` |
| `disableCropBoxDeformation` | `cropAuxiliaryIndicatorConfig.disableCropBoxDeformation` |
| `cropAuxiliaryIndicatorStyle` | `cropAuxiliaryIndicatorConfig.style` |
| `showRotationDial` | `showAttachedRotationControlView` |

All internal code and both example apps already use the replacement names — verified nothing in `Sources/`, `Example/`, or `SwiftUIExample/` references the removed ones.

## 2. Slim the public `CropInfo`

`CropInfo` is public and appears throughout the crop API (`crop(image:by:)`, `getCropInfo()`, delegate callbacks). It exposed five fields that are pure view-hierarchy plumbing — used **only** to reconstruct and invert the exact on-screen transform in the perspective / large-image crop paths:

`skewSublayerTransform`, `scrollContentOffset`, `scrollBoundsSize`, `imageContainerFrame`, `scrollViewTransform`

These move out of the public struct + `init` into an internal `CropInfo.ViewReconstruction`, stored as an internal optional that `getCropInfo()` populates. The public surface now carries only semantic crop parameters (translation, rotation, scale, sizes, region, skew degrees).

**Round-trip safety:** a `CropInfo` obtained from Mantis (delegate / `getCropInfo()`) keeps its reconstruction data across a value copy, so passing it back into `crop(image:by:)` works exactly as before. A hand-built `CropInfo` (public `init`) has no reconstruction data, so the perspective / CIImage paths return `nil` — the same outcome the previous zero-value guards produced, just explicit.

### Migration
- Consumers that only pass a delegate-provided `CropInfo` back to a crop call: **no change**.
- Consumers that persist the **semantic** fields of a `CropInfo` and rebuild it later via the public `init` for offline re-cropping: **no change** for the standard path (no skew, no `maxImagePixelCount` overflow). The perspective and CIImage paths return `nil` for a rebuilt `CropInfo` — the same outcome the previous zero-value guards produced.
- Consumers that read those five fields off `CropInfo`, or construct a `CropInfo` with them: compile error. Note this removes one previously-possible (if unwieldy) capability: serializing all five view fields to re-crop a **perspective-skewed or oversized** image offline in a *later session*. Cross-session restore of perspective crops now requires a Mantis-provided `CropInfo` from the same session; first-class support for persisting `CropInfo` (making it `Codable`, with `ViewReconstruction` encoded opaquely) is tracked separately for 3.x.

## Validation
- Builds clean at the **real `IPHONEOS_DEPLOYMENT_TARGET=15.0`**
- Full suite **148 tests, 0 failures** (test `CropInfo` builders updated to set `viewReconstruction` via `@testable` access)
- SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated crop handling to keep reconstruction details separate from the main crop settings, improving internal consistency.

* **Bug Fixes**
  * Fixed perspective cropping to use the correct reconstruction values during image processing.
  * Improved handling of invalid crop geometry so degenerate crop data is more reliably rejected.

* **Chores**
  * Removed several deprecated crop configuration options from the public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
