### PR TITLE
feat: observable CropSession + declarative ImageCropper; per-session TransformStack

### DIFF
--- a/Example/DemoViewController.swift
+++ b/Example/DemoViewController.swift
@@ -517,6 +517,8 @@ extension DemoViewController: ImagePickerDelegate {
     func didSelect(image: UIImage?) {
         guard let image = image else { return }
         self.image = image
+        // A transformation is only valid for the image it was created from.
+        transformation = nil
         croppedImageView.image = cachedDisplayImage
     }
 }

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -337,6 +337,8 @@ extension ViewController: ImagePickerDelegate {
         }
         
         self.image = image
+        // A transformation is only valid for the image it was created from.
+        transformation = nil
         croppedImageView.image = image
     }
 }

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		F2B4FDA72A3B69B600667F22 /* SlideRulerPositionHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B4FDA52A3B69B600667F22 /* SlideRulerPositionHelper.swift */; };
 		F2B4FDA82A3B69B600667F22 /* SlideRuler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B4FDA62A3B69B600667F22 /* SlideRuler.swift */; };
 		F2D700392DA1B8630063EE6C /* ImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2D700382DA1B8630063EE6C /* ImageCropper.swift */; };
+		3A0C501B2E1B00010063EE02 /* CropSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0C501A2E1B00010063EE01 /* CropSession.swift */; };
+		3A0C501D2E1B00010063EE04 /* DeclarativeImageCropper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0C501C2E1B00010063EE03 /* DeclarativeImageCropper.swift */; };
+		3A0C501F2E1B00010063EE06 /* CropSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0C501E2E1B00010063EE05 /* CropSessionTests.swift */; };
 		FEDAAD8625205CC300D95667 /* RatioSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDAAD8525205CC300D95667 /* RatioSelector.swift */; };
 		FEDAAD8C25205DE900D95667 /* RatioItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDAAD8B25205DE900D95667 /* RatioItemView.swift */; };
 		OBJ_100 /* RotationDialPlate.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_48 /* RotationDialPlate.swift */; };
@@ -267,6 +270,9 @@
 		F2B4FDA52A3B69B600667F22 /* SlideRulerPositionHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideRulerPositionHelper.swift; sourceTree = "<group>"; };
 		F2B4FDA62A3B69B600667F22 /* SlideRuler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SlideRuler.swift; sourceTree = "<group>"; };
 		F2D700382DA1B8630063EE6C /* ImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCropper.swift; sourceTree = "<group>"; };
+		3A0C501A2E1B00010063EE01 /* CropSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropSession.swift; sourceTree = "<group>"; };
+		3A0C501C2E1B00010063EE03 /* DeclarativeImageCropper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarativeImageCropper.swift; sourceTree = "<group>"; };
+		3A0C501E2E1B00010063EE05 /* CropSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropSessionTests.swift; sourceTree = "<group>"; };
 		FEDAAD8525205CC300D95667 /* RatioSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatioSelector.swift; sourceTree = "<group>"; };
 		FEDAAD8B25205DE900D95667 /* RatioItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatioItemView.swift; sourceTree = "<group>"; };
 		"Mantis::Mantis::Product" /* Mantis.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Mantis.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -415,6 +421,8 @@
 			isa = PBXGroup;
 			children = (
 				F2D700382DA1B8630063EE6C /* ImageCropper.swift */,
+				3A0C501A2E1B00010063EE01 /* CropSession.swift */,
+				3A0C501C2E1B00010063EE03 /* DeclarativeImageCropper.swift */,
 			);
 			path = SwiftUIView;
 			sourceTree = "<group>";
@@ -553,6 +561,7 @@
 				F251B36D299B9A52006325B0 /* CropWorkbenchViewTests.swift */,
 				F24DCFE729AB0A7000D8E8C1 /* CropAuxiliaryIndicatorViewTests.swift */,
 				97FA9A842BAFA570001E67D9 /* TransformStackTests.swift */,
+				3A0C501E2E1B00010063EE05 /* CropSessionTests.swift */,
 				AA00000000000000000000A2 /* CICropEquivalenceTests.swift */,
 				AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */,
 				AA00000000000000000000F2 /* SkewPositioningTests.swift */,
@@ -799,6 +808,7 @@
 			files = (
 				F251B36E299B9A52006325B0 /* CropWorkbenchViewTests.swift in Sources */,
 				97FA9A852BAFA570001E67D9 /* TransformStackTests.swift in Sources */,
+				3A0C501F2E1B00010063EE06 /* CropSessionTests.swift in Sources */,
 				AA00000000000000000000A1 /* CICropEquivalenceTests.swift in Sources */,
 				AA00000000000000000000B1 /* PerspectiveTransformHelperTests.swift in Sources */,
 				AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */,
@@ -839,6 +849,8 @@
 				OBJ_71 /* CropMaskViewManager.swift in Sources */,
 				66100E11294BAEB6001C8593 /* CropScrollViewProtocol.swift in Sources */,
 				F2D700392DA1B8630063EE6C /* ImageCropper.swift in Sources */,
+				3A0C501B2E1B00010063EE02 /* CropSession.swift in Sources */,
+				3A0C501D2E1B00010063EE04 /* DeclarativeImageCropper.swift in Sources */,
 				OBJ_72 /* CropAuxiliaryIndicatorView.swift in Sources */,
 				F209F88C2F4D756D00E15AEA /* SlideDialIconDrawer.swift in Sources */,
 				F25821622F41800F0091CA49 /* PerspectiveTransformHelper.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -113,6 +113,63 @@ github "guoyingtao/Mantis"
 
 ### SwiftUI
 
+#### Declarative API (Mantis 3.0+)
+
+`ImageCropper` is a declarative SwiftUI view configured with modifiers:
+
+```Swift
+struct MyView: View {
+    @State private var croppedImage: UIImage?
+
+    var body: some View {
+        ImageCropper(image: myImage)
+            .cropShape(.circle)
+            .aspectRatio(.fixed(16/9))
+            .onCrop { result in
+                croppedImage = result.croppedImage
+            }
+    }
+}
+```
+
+To build your own controls, attach a `CropSession`. It exposes `canUndo`, `canRedo`,
+`isResettable` and the live `transformation` as observable state (fine-grained
+`Observation` tracking on iOS 17+, `ObservableObject` on iOS 15/16), and drives the
+cropper with plain methods instead of enum bindings:
+
+```Swift
+struct MyCropperView: View {
+    @StateObject private var session = CropSession()
+    @State private var croppedImage: UIImage?
+
+    var body: some View {
+        VStack {
+            ImageCropper(image: myImage, session: session)
+                .builtInToolbarVisible(false)
+                .onCrop { result in croppedImage = result.croppedImage }
+
+            HStack {
+                Button("Undo") { session.undo() }
+                    .disabled(!session.canUndo)
+                Button("Redo") { session.redo() }
+                    .disabled(!session.canRedo)
+                Button("Reset") { session.reset() }
+                    .disabled(!session.isResettable)
+                Button("Rotate") { session.rotate(.clockwise) }
+                Button("Flip") { session.flip(.horizontal) }
+                Button("Done") { session.crop() }
+            }
+        }
+    }
+}
+```
+
+Available modifiers: `.cropShape(_:)`, `.aspectRatio(_:)`, `.builtInToolbarVisible(_:)`,
+`.appearance(_:)`, `.configure { $0... }` (escape hatch to the full `Mantis.Config`),
+`.onCrop(_:)`, `.onCancel(_:)`, `.onCropFailed(_:)`.
+
+#### Binding-based API
+
 * Create an ImageCropperView from Mantis with default config
 
 ```Swift

--- a/Sources/Mantis/CropViewController/CropViewController+CropViewDelegate.swift
+++ b/Sources/Mantis/CropViewController/CropViewController+CropViewDelegate.swift
@@ -56,8 +56,7 @@ extension CropViewController: CropViewDelegate {
         currentCropState = cropView.makeCropState()
 
         if previous != currentCropState {
-            TransformStack
-                .shared
+            transformStack
                 .pushTransformRecordOntoStack(transformType: .transform,
                                               previous: previous, current:
                                                 currentCropState,

--- a/Sources/Mantis/CropViewController/CropViewController.swift
+++ b/Sources/Mantis/CropViewController/CropViewController.swift
@@ -29,10 +29,14 @@ open class CropViewController: UIViewController {
     public var config = Mantis.Config() {
         didSet {
             if config.enableUndoRedo {
-                TransformStack.shared.transformDelegate = self
+                transformStack.transformDelegate = self
             }
         }
     }
+
+    /// Undo/redo bookkeeping scoped to this crop session, so concurrent
+    /// sessions (e.g. multiple windows) keep independent undo histories.
+    let transformStack = TransformStack()
     
     var cropView: CropViewProtocol! {
         didSet {
@@ -118,7 +122,13 @@ open class CropViewController: UIViewController {
         }
 
         view.backgroundColor = AppearanceColorPreset.mainBackground(for: config.appearanceMode)
-        
+
+        // The config property observer doesn't fire when config is set in init,
+        // so wire up the undo stack here as well.
+        if config.enableUndoRedo {
+            transformStack.transformDelegate = self
+        }
+
         cropView.initialSetup(delegate: self, presetFixedRatioType: config.presetFixedRatioType)
         createCropToolbar()
         if config.cropToolbarConfig.ratioCandidatesShowType == .alwaysShowRatioList
@@ -251,8 +261,7 @@ extension CropViewController {
         
         if config.enableUndoRedo {
             let current = cropView.makeCropState()
-            TransformStack
-                .shared
+            transformStack
                 .pushTransformRecordOntoStack(transformType: .resetTransforms,
                                               previous: previous,
                                               current: current,

--- a/Sources/Mantis/Helpers/TransformRecord.swift
+++ b/Sources/Mantis/Helpers/TransformRecord.swift
@@ -6,85 +6,90 @@ enum TransformType {
 }
 
 class TransformRecord: NSObject {
-    
+
+    /// The stack this record belongs to. Weak because the stack's owner
+    /// (`CropViewController`) also owns the `UndoManager` that retains records.
+    private weak var stack: TransformStack?
+
     private let transformType: TransformType
-    
+
     private let actionName: String
-    
+
     private let previousValues: [String: CropState]
     private let currentValues: [String: CropState]
-    
+
     private var useCurrent: Bool = true
-    
-    init(transformType: TransformType, actionName: String, previousValues: [String: CropState], currentValues: [String: CropState]) {
-        
+
+    init(stack: TransformStack,
+         transformType: TransformType,
+         actionName: String,
+         previousValues: [String: CropState],
+         currentValues: [String: CropState]) {
+
+        self.stack = stack
         self.transformType = transformType
         self.actionName = actionName
         self.previousValues = previousValues
         self.currentValues = currentValues
-        
+
         super.init()
     }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
+
     func updateTransformState() {
-        guard let transformDelegate = TransformStack.shared.transformDelegate else { return }
+        guard let transformDelegate = stack?.transformDelegate else { return }
 
         guard let cropState = self.useCurrent ?
                 self.currentValues[.kCurrentTransformState]
                 : self.previousValues[.kCurrentTransformState] else {
             return
         }
-        
+
         transformDelegate.updateCropState(cropState)
     }
-    
+
     // Add/Redo
     @objc func addAdjustmentToStack(_ applyTransform: NSNumber? = nil) {
-        
-        guard let transformDelegate = TransformStack.shared.transformDelegate else { return }
-        
+
+        guard let stack = stack, let transformDelegate = stack.transformDelegate else { return }
+
         self.useCurrent = true
-        
+
         if applyTransform?.boolValue == true {
             updateTransformState()
         }
-        
-        TransformStack.shared.pushTransformRecord(self)
-        
+
+        stack.pushTransformRecord(self)
+
         // register the undo event
         transformDelegate.getUndoManager().registerUndo(withTarget: self, selector: #selector(removeAdjustmentFromStack), object: nil)
-        
+
         transformDelegate.getUndoManager().setActionName(self.actionName)
-        
+
         transformDelegate.updateEnableStateForReset(self.transformType != .resetTransforms)
     }
-    
+
     // Undo
     @objc func removeAdjustmentFromStack() {
-        
-        guard let transformDelegate = TransformStack.shared.transformDelegate else { return }
-        
+
+        guard let stack = stack, let transformDelegate = stack.transformDelegate else { return }
+
         self.useCurrent = false
-        
+
         self.updateTransformState()
-        
-        TransformStack.shared.popTransformStack()
+
+        stack.popTransformStack()
         let applyTransform = true
         transformDelegate
             .getUndoManager()
             .registerUndo(withTarget: self,
                           selector: #selector(addAdjustmentToStack),
                           object: NSNumber(value: applyTransform))
-        
+
         transformDelegate.getUndoManager().setActionName(self.actionName)
-        
+
         if self.transformType == .resetTransforms {
             transformDelegate.updateEnableStateForReset(true)
-        } else if 0 == TransformStack.shared.top {
+        } else if 0 == stack.top {
             transformDelegate.updateEnableStateForReset(false)
         }
     }

--- a/Sources/Mantis/Helpers/TransformStack.swift
+++ b/Sources/Mantis/Helpers/TransformStack.swift
@@ -1,29 +1,31 @@
 import UIKit
 
+/// A per-crop-session undo/redo bookkeeping stack.
+///
+/// Each `CropViewController` owns its own instance, so multiple concurrent
+/// crop sessions (e.g. two windows on iPad) never pollute each other's
+/// undo history.
 class TransformStack: NSObject {
-    
-    static var shared: TransformStack = TransformStack()
-    
-    weak var transformDelegate: TransformDelegate?
-    
+
+    weak var transformDelegate: TransformDelegate? {
+        didSet {
+            NotificationCenter.default.removeObserver(self, name: .NSUndoManagerCheckpoint, object: nil)
+            if let transformDelegate = transformDelegate {
+                // Observe only this session's undo manager so checkpoints from
+                // other concurrent crop sessions don't trigger this stack.
+                NotificationCenter.default.addObserver(
+                    self,
+                    selector: #selector(self.undoStatusChanged(notification:)),
+                    name: .NSUndoManagerCheckpoint,
+                    object: transformDelegate.getUndoManager())
+            }
+        }
+    }
+
     private var transformAdjustmentsStack: [TransformRecord] = []
-    
+
     var top: Int = 0
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    private override init() {
-        super.init()
-        
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.undoStatusChanged(notification:)),
-            name: .NSUndoManagerCheckpoint,
-            object: nil)
-    }
-    
+
     func pushTransformRecord(_ record: TransformRecord) {
         if transformAdjustmentsStack.count > top {
             transformAdjustmentsStack.remove(at: top)
@@ -37,38 +39,39 @@ class TransformStack: NSObject {
             top -= 1
         }
     }
-    
+
     func reset() {
         transformAdjustmentsStack.removeAll()
         top = 0
     }
-    
+
     @objc func undoStatusChanged(notification: NSNotification?) {
         guard let transformDelegate = transformDelegate else { return }
         transformDelegate.updateEnableStateForUndo(transformDelegate.isUndoEnabled())
         transformDelegate.updateEnableStateForRedo(transformDelegate.isRedoEnabled())
     }
-    
+
     func pushTransformRecordOntoStack(transformType: TransformType, previous: CropState, current: CropState, userGenerated: Bool) {
         if userGenerated {
-            
+
             let actionString: String
-            
+
             switch transformType {
             case .transform:
                 actionString = LocalizedHelper.getString("Mantis.ChangeCrop", value: "Change Crop")
             case .resetTransforms:
                 actionString = LocalizedHelper.getString("Mantis.ResetChanges", value: "Reset Changes")
             }
-            
+
             let previousValue: [String: CropState] = [.kCurrentTransformState: previous]
             let currentValue: [String: CropState] = [.kCurrentTransformState: current]
-            
-            let transformRecord = TransformRecord(transformType: transformType, 
+
+            let transformRecord = TransformRecord(stack: self,
+                                                  transformType: transformType,
                                                   actionName: actionString,
                                                   previousValues: previousValue,
                                                   currentValues: currentValue)
-            
+
             transformRecord.addAdjustmentToStack()
         }
     }

--- a/Sources/Mantis/SwiftUIView/CropSession.swift
+++ b/Sources/Mantis/SwiftUIView/CropSession.swift
@@ -1,0 +1,227 @@
+//
+//  CropSession.swift
+//  Mantis
+//
+//  Created for Mantis 3.0.
+//
+
+import UIKit
+#if canImport(Combine)
+import Combine
+#endif
+#if canImport(Observation)
+import Observation
+#endif
+
+/// Direction for the 90-degree rotations triggered from a ``CropSession``.
+public enum RotationDirection: Sendable {
+    case clockwise
+    case counterClockwise
+}
+
+/// Axis for the flips triggered from a ``CropSession``.
+public enum FlipDirection: Sendable {
+    case horizontal
+    case vertical
+}
+
+/// Aspect ratio setting for the crop box.
+public enum CropAspectRatio: Equatable, Sendable {
+    /// The crop box can be freely resized.
+    case free
+    /// The crop box is locked to `width / height` (e.g. `.fixed(16/9)`).
+    case fixed(CGFloat)
+}
+
+/// An observable handle to a live crop session.
+///
+/// Create a session, pass it to ``ImageCropper``, and drive the cropper
+/// imperatively while observing its state declaratively:
+///
+/// ```swift
+/// @StateObject private var session = CropSession()
+///
+/// var body: some View {
+///     VStack {
+///         ImageCropper(image: image, session: session)
+///             .cropShape(.circle)
+///             .onCrop { result in croppedImage = result.croppedImage }
+///         HStack {
+///             Button("Undo") { session.undo() }.disabled(!session.canUndo)
+///             Button("Redo") { session.redo() }.disabled(!session.canRedo)
+///             Button("Rotate") { session.rotate(.clockwise) }
+///             Button("Done") { session.crop() }
+///         }
+///     }
+/// }
+/// ```
+///
+/// On iOS 17 and later the session also participates in the Observation
+/// framework, so it can be stored with `@State` and observed with the
+/// fine-grained `@Observable` tracking; on earlier systems it behaves as a
+/// plain `ObservableObject`. All members must be used from the main thread.
+public final class CropSession: ObservableObject {
+
+    weak var cropViewController: CropViewController?
+
+    public init() {}
+
+    // MARK: - Observable state
+
+    private var _canUndo = false
+    /// Whether an undo step is available.
+    public internal(set) var canUndo: Bool {
+        get {
+            access(\.canUndo)
+            return _canUndo
+        }
+        set {
+            guard newValue != _canUndo else { return }
+            objectWillChange.send()
+            withMutation(\.canUndo) { _canUndo = newValue }
+        }
+    }
+
+    private var _canRedo = false
+    /// Whether a redo step is available.
+    public internal(set) var canRedo: Bool {
+        get {
+            access(\.canRedo)
+            return _canRedo
+        }
+        set {
+            guard newValue != _canRedo else { return }
+            objectWillChange.send()
+            withMutation(\.canRedo) { _canRedo = newValue }
+        }
+    }
+
+    private var _isResettable = false
+    /// Whether the current state differs from the initial one, i.e. reset would change something.
+    public internal(set) var isResettable: Bool {
+        get {
+            access(\.isResettable)
+            return _isResettable
+        }
+        set {
+            guard newValue != _isResettable else { return }
+            objectWillChange.send()
+            withMutation(\.isResettable) { _isResettable = newValue }
+        }
+    }
+
+    private var _transformation: Transformation?
+    /// The transformation currently applied to the image, updated live as the user pans/zooms/rotates.
+    public internal(set) var transformation: Transformation? {
+        get {
+            access(\.transformation)
+            return _transformation
+        }
+        set {
+            guard newValue != _transformation else { return }
+            objectWillChange.send()
+            withMutation(\.transformation) { _transformation = newValue }
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Rotates the image by 90 degrees. No-op when the session is not attached to a cropper.
+    public func rotate(_ direction: RotationDirection = .clockwise) {
+        switch direction {
+        case .clockwise:
+            cropViewController?.didSelectClockwiseRotate()
+        case .counterClockwise:
+            cropViewController?.didSelectCounterClockwiseRotate()
+        }
+    }
+
+    /// Flips the image around the given axis.
+    public func flip(_ direction: FlipDirection = .horizontal) {
+        switch direction {
+        case .horizontal:
+            cropViewController?.didSelectHorizontallyFlip()
+        case .vertical:
+            cropViewController?.didSelectVerticallyFlip()
+        }
+    }
+
+    /// Performs the crop. The result is delivered through ``ImageCropper/onCrop(_:)``.
+    public func crop() {
+        cropViewController?.crop()
+    }
+
+    /// Reverts the last user adjustment. Requires undo support (enabled automatically
+    /// when the session is attached through ``ImageCropper``).
+    public func undo() {
+        cropViewController?.didSelectUndo()
+    }
+
+    /// Re-applies the last undone adjustment.
+    public func redo() {
+        cropViewController?.didSelectRedo()
+    }
+
+    /// Resets all adjustments back to the initial state.
+    public func reset() {
+        cropViewController?.didSelectReset()
+    }
+
+    /// Changes the crop box aspect ratio while the session is running.
+    public func setAspectRatio(_ ratio: CropAspectRatio) {
+        switch ratio {
+        case .free:
+            cropViewController?.didSelectFreeRatio()
+        case .fixed(let value):
+            cropViewController?.didSelectRatio(ratio: Double(value))
+        }
+    }
+
+    // MARK: - Attachment
+
+    func attach(to cropViewController: CropViewController) {
+        self.cropViewController = cropViewController
+        canUndo = false
+        canRedo = false
+        isResettable = false
+    }
+
+    // MARK: - iOS 17+ Observation bridging
+
+    // Stored as Any so the class itself stays available on iOS 15/16;
+    // ObservationRegistrar is a struct wrapping shared reference storage,
+    // so copying it out of the Any box preserves registration state.
+    private let registrarBox: Any? = {
+#if canImport(Observation)
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
+            return ObservationRegistrar()
+        }
+#endif
+        return nil
+    }()
+
+    private func access<Member>(_ keyPath: KeyPath<CropSession, Member>) {
+#if canImport(Observation)
+        if #available(iOS 17.0, macCatalyst 17.0, *),
+           let registrar = registrarBox as? ObservationRegistrar {
+            registrar.access(self, keyPath: keyPath)
+        }
+#endif
+    }
+
+    private func withMutation<Member>(_ keyPath: KeyPath<CropSession, Member>, _ mutation: () -> Void) {
+#if canImport(Observation)
+        if #available(iOS 17.0, macCatalyst 17.0, *),
+           let registrar = registrarBox as? ObservationRegistrar {
+            registrar.withMutation(of: self, keyPath: keyPath, mutation)
+            return
+        }
+#endif
+        mutation()
+    }
+}
+
+#if canImport(Observation)
+@available(iOS 17.0, macCatalyst 17.0, *)
+extension CropSession: Observable {}
+#endif

--- a/Sources/Mantis/SwiftUIView/DeclarativeImageCropper.swift
+++ b/Sources/Mantis/SwiftUIView/DeclarativeImageCropper.swift
@@ -1,0 +1,222 @@
+//
+//  DeclarativeImageCropper.swift
+//  Mantis
+//
+//  Created for Mantis 3.0.
+//
+
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// The output of a successful crop performed through ``ImageCropper``.
+public struct CropResult {
+    public let croppedImage: UIImage
+    public let transformation: Transformation
+    public let cropInfo: CropInfo
+}
+
+/// A declarative SwiftUI cropper.
+///
+/// ```swift
+/// ImageCropper(image: image)
+///     .cropShape(.circle)
+///     .aspectRatio(.fixed(16/9))
+///     .onCrop { result in
+///         croppedImage = result.croppedImage
+///     }
+/// ```
+///
+/// Pass a ``CropSession`` to drive the cropper from your own controls
+/// (`session.rotate()`, `session.crop()`, ...) and to observe `canUndo`,
+/// `canRedo`, `isResettable` and the live `transformation`.
+public struct ImageCropper: View {
+    private let image: UIImage
+    private let session: CropSession?
+
+    private(set) var config: Mantis.Config
+    private var onCropHandler: ((CropResult) -> Void)?
+    private var onCancelHandler: (() -> Void)?
+    private var onCropFailedHandler: ((UIImage) -> Void)?
+
+    /// Creates a cropper for `image`.
+    ///
+    /// - Parameters:
+    ///   - image: The image to crop.
+    ///   - session: An optional ``CropSession`` used to control the cropper and
+    ///     observe its state. Attaching a session enables undo/redo support.
+    ///   - config: An optional base configuration; the declarative modifiers are
+    ///     applied on top of it.
+    public init(image: UIImage, session: CropSession? = nil, config: Mantis.Config = Mantis.Config()) {
+        self.image = image
+        self.session = session
+        self.config = config
+    }
+
+    public var body: some View {
+        var resolvedConfig = config
+        if session != nil {
+            // Undo/redo state is part of the session contract.
+            resolvedConfig.enableUndoRedo = true
+        }
+        return ImageCropperBridge(image: image,
+                                  config: resolvedConfig,
+                                  session: session,
+                                  onCrop: onCropHandler,
+                                  onCancel: onCancelHandler,
+                                  onCropFailed: onCropFailedHandler)
+    }
+
+    // MARK: - Modifiers
+
+    /// Sets the crop shape, e.g. `.circle`, `.square` or `.roundedRect(radiusToShortSide: 0.1)`.
+    public func cropShape(_ shape: CropShapeType) -> ImageCropper {
+        var copy = self
+        copy.config.cropViewConfig.cropShapeType = shape
+        switch shape {
+        case .circle, .square, .heart:
+            copy.config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 1)
+        default:
+            break
+        }
+        return copy
+    }
+
+    /// Sets the crop box aspect ratio: `.free` or `.fixed(16/9)`.
+    public func aspectRatio(_ ratio: CropAspectRatio) -> ImageCropper {
+        var copy = self
+        switch ratio {
+        case .free:
+            copy.config.presetFixedRatioType = .canUseMultiplePresetFixedRatio()
+        case .fixed(let value):
+            copy.config.presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: Double(value))
+        }
+        return copy
+    }
+
+    /// Shows or hides Mantis's built-in crop toolbar. Hide it when you build
+    /// your own controls on top of a ``CropSession``.
+    public func builtInToolbarVisible(_ visible: Bool) -> ImageCropper {
+        var copy = self
+        copy.config.showAttachedCropToolbar = visible
+        return copy
+    }
+
+    /// Sets the appearance (`.forceDark`, `.forceLight` or `.system`).
+    public func appearance(_ mode: AppearanceMode) -> ImageCropper {
+        var copy = self
+        copy.config.appearanceMode = mode
+        return copy
+    }
+
+    /// Escape hatch for settings without a dedicated modifier.
+    public func configure(_ transform: (inout Mantis.Config) -> Void) -> ImageCropper {
+        var copy = self
+        transform(&copy.config)
+        return copy
+    }
+
+    /// Called with the cropped image after ``CropSession/crop()`` or the
+    /// built-in toolbar's crop button succeeds.
+    public func onCrop(_ handler: @escaping (CropResult) -> Void) -> ImageCropper {
+        var copy = self
+        copy.onCropHandler = handler
+        return copy
+    }
+
+    /// Called when the user cancels from the built-in toolbar.
+    public func onCancel(_ handler: @escaping () -> Void) -> ImageCropper {
+        var copy = self
+        copy.onCancelHandler = handler
+        return copy
+    }
+
+    /// Called with the original image when cropping fails.
+    public func onCropFailed(_ handler: @escaping (UIImage) -> Void) -> ImageCropper {
+        var copy = self
+        copy.onCropFailedHandler = handler
+        return copy
+    }
+}
+
+// MARK: - UIKit bridge
+
+private struct ImageCropperBridge: UIViewControllerRepresentable {
+    let image: UIImage
+    let config: Mantis.Config
+    let session: CropSession?
+
+    let onCrop: ((CropResult) -> Void)?
+    let onCancel: (() -> Void)?
+    let onCropFailed: ((UIImage) -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIViewController(context: Context) -> CropViewController {
+        let cropViewController = Mantis.cropViewController(image: image, config: config)
+        cropViewController.delegate = context.coordinator
+        session?.attach(to: cropViewController)
+        return cropViewController
+    }
+
+    func updateUIViewController(_ uiViewController: CropViewController, context: Context) {
+        // The crop view controller is configured once in makeUIViewController;
+        // only the callbacks need to track the latest view value.
+        context.coordinator.parent = self
+    }
+
+    final class Coordinator: CropViewControllerDelegate {
+        var parent: ImageCropperBridge
+
+        init(_ parent: ImageCropperBridge) {
+            self.parent = parent
+        }
+
+        func cropViewControllerDidCrop(_ cropViewController: CropViewController,
+                                       cropped: UIImage,
+                                       transformation: Transformation,
+                                       cropInfo: CropInfo) {
+            parent.session?.transformation = transformation
+            parent.onCrop?(CropResult(croppedImage: cropped,
+                                      transformation: transformation,
+                                      cropInfo: cropInfo))
+        }
+
+        func cropViewControllerDidFailToCrop(_ cropViewController: CropViewController, original: UIImage) {
+            parent.onCropFailed?(original)
+        }
+
+        func cropViewControllerDidCancel(_ cropViewController: CropViewController, original: UIImage) {
+            parent.onCancel?()
+        }
+
+        func cropViewControllerDidImageTransformed(_ cropViewController: CropViewController, transformation: Transformation) {
+            parent.session?.transformation = transformation
+        }
+
+        func cropViewController(_ cropViewController: CropViewController, didBecomeResettable resettable: Bool) {
+            parent.session?.isResettable = resettable
+        }
+
+        func cropViewController(_ cropViewController: CropViewController, didUpdateEnableStateForUndo enable: Bool) {
+            parent.session?.canUndo = enable
+        }
+
+        func cropViewController(_ cropViewController: CropViewController, didUpdateEnableStateForRedo enable: Bool) {
+            parent.session?.canRedo = enable
+        }
+    }
+}
+
+// MARK: - Bare-case shape conveniences
+
+// Let call sites write `.cropShape(.circle)` instead of `.circle()` for the
+// cases whose associated values all have defaults.
+public extension CropShapeType {
+    static var circle: CropShapeType { .circle() }
+    static var ellipse: CropShapeType { .ellipse() }
+    static var diamond: CropShapeType { .diamond() }
+    static var heart: CropShapeType { .heart() }
+}
+#endif

--- a/Sources/Mantis/SwiftUIView/DeclarativeImageCropper.swift
+++ b/Sources/Mantis/SwiftUIView/DeclarativeImageCropper.swift
@@ -29,6 +29,13 @@ public struct CropResult {
 /// Pass a ``CropSession`` to drive the cropper from your own controls
 /// (`session.rotate()`, `session.crop()`, ...) and to observe `canUndo`,
 /// `canRedo`, `isResettable` and the live `transformation`.
+///
+/// - Important: The configuration produced by the modifiers is applied once,
+///   when the underlying crop view controller is created; changing modifier
+///   values on later view updates has no effect. Use
+///   ``CropSession/setAspectRatio(_:)`` to change the ratio at runtime.
+///   The `image` is the exception: passing a different image instance updates
+///   the running cropper in place.
 public struct ImageCropper: View {
     private let image: UIImage
     private let session: CropSession?
@@ -156,18 +163,24 @@ private struct ImageCropperBridge: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> CropViewController {
         let cropViewController = Mantis.cropViewController(image: image, config: config)
         cropViewController.delegate = context.coordinator
+        context.coordinator.appliedImage = image
         session?.attach(to: cropViewController)
         return cropViewController
     }
 
     func updateUIViewController(_ uiViewController: CropViewController, context: Context) {
-        // The crop view controller is configured once in makeUIViewController;
-        // only the callbacks need to track the latest view value.
+        // The configuration is applied once in makeUIViewController; only the
+        // callbacks and the image track the latest view value.
         context.coordinator.parent = self
+        if context.coordinator.appliedImage !== image {
+            context.coordinator.appliedImage = image
+            uiViewController.update(image)
+        }
     }
 
     final class Coordinator: CropViewControllerDelegate {
         var parent: ImageCropperBridge
+        var appliedImage: UIImage?
 
         init(_ parent: ImageCropperBridge) {
             self.parent = parent

--- a/SwiftUIExample/MantisSwiftUIExample.xcodeproj/project.pbxproj
+++ b/SwiftUIExample/MantisSwiftUIExample.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		5F5266B7263B490500615369 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F5266B6263B490500615369 /* Assets.xcassets */; };
 		5F5266BA263B490500615369 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5F5266B9263B490500615369 /* Preview Assets.xcassets */; };
 		F24836F5299DE6AD0008477C /* ImageCropperWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24836F4299DE6AD0008477C /* ImageCropperWrapper.swift */; };
+		3A0C50212E1B00020063EE12 /* DeclarativeCropperDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0C50202E1B00020063EE11 /* DeclarativeCropperDemoView.swift */; };
 		F24836F7299DE7630008477C /* AdaptiveStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24836F6299DE7630008477C /* AdaptiveStack.swift */; };
 		F24836F9299E14B00008477C /* CustomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24836F8299E14B00008477C /* CustomViewController.swift */; };
 		F24836FB299E46C90008477C /* CropShapeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F24836FA299E46C90008477C /* CropShapeListView.swift */; };
@@ -32,6 +33,7 @@
 		7B97999EBC5EA043ADD0C5B3 /* Pods-MantisSwiftUIExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MantisSwiftUIExample.release.xcconfig"; path = "Target Support Files/Pods-MantisSwiftUIExample/Pods-MantisSwiftUIExample.release.xcconfig"; sourceTree = "<group>"; };
 		D522526BBC7FB0BCB92F0553 /* Pods_MantisSwiftUIExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MantisSwiftUIExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F24836F4299DE6AD0008477C /* ImageCropperWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCropperWrapper.swift; sourceTree = "<group>"; };
+		3A0C50202E1B00020063EE11 /* DeclarativeCropperDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarativeCropperDemoView.swift; sourceTree = "<group>"; };
 		F24836F6299DE7630008477C /* AdaptiveStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveStack.swift; sourceTree = "<group>"; };
 		F24836F8299E14B00008477C /* CustomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomViewController.swift; sourceTree = "<group>"; };
 		F24836FA299E46C90008477C /* CropShapeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropShapeListView.swift; sourceTree = "<group>"; };
@@ -76,6 +78,7 @@
 				5F5266B2263B490400615369 /* MantisSwiftUIExampleApp.swift */,
 				5F5266B4263B490400615369 /* ContentView.swift */,
 				F24836F4299DE6AD0008477C /* ImageCropperWrapper.swift */,
+				3A0C50202E1B00020063EE11 /* DeclarativeCropperDemoView.swift */,
 				F24836F6299DE7630008477C /* AdaptiveStack.swift */,
 				F24836F8299E14B00008477C /* CustomViewController.swift */,
 				F24836FA299E46C90008477C /* CropShapeListView.swift */,
@@ -236,6 +239,7 @@
 				F24836F9299E14B00008477C /* CustomViewController.swift in Sources */,
 				F24836F7299DE7630008477C /* AdaptiveStack.swift in Sources */,
 				F24836F5299DE6AD0008477C /* ImageCropperWrapper.swift in Sources */,
+				3A0C50212E1B00020063EE12 /* DeclarativeCropperDemoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -10,15 +10,11 @@ import Mantis
 
 struct ContentView: View {
     @State private var image: UIImage? = UIImage(named: "sunflower")!
-    @State private var showingCropper = false
+    @State private var cropperOptions: DeclarativeCropperOptions?
     @State private var showingCustomToolbarCropper = false
     @State private var showingLegacyCropper = false
     @State private var showingCropShapeList = false
     @State private var cropShapeType: Mantis.CropShapeType = .rect
-    @State private var cropAspectRatio: CropAspectRatio = .free
-    @State private var showsRotationControl = true
-    @State private var usesSlideDial = false
-    @State private var enablesPerspectiveCorrection = false
     @State private var showingRestorableCropper = false
     @State private var savedTransformation: Transformation?
     @State private var contentHeight: CGFloat = 0
@@ -37,15 +33,9 @@ struct ContentView: View {
             createImageHolder()
             createFeatureDemoList()
         }
-        .fullScreenCover(isPresented: $showingCropper, content: {
-            DeclarativeCropperView(image: $image,
-                                   cropShapeType: cropShapeType,
-                                   aspectRatio: cropAspectRatio,
-                                   showsRotationControl: showsRotationControl,
-                                   usesSlideDial: usesSlideDial,
-                                   enablesPerspectiveCorrection: enablesPerspectiveCorrection)
-            .onDisappear(perform: reset)
-            .ignoresSafeArea()
+        .fullScreenCover(item: $cropperOptions, onDismiss: reset, content: { options in
+            DeclarativeCropperView(image: $image, options: options)
+                .ignoresSafeArea()
         })
         .fullScreenCover(isPresented: $showingRestorableCropper, content: {
             RestorableCropperDemoView(image: $image,
@@ -63,7 +53,16 @@ struct ContentView: View {
                 .ignoresSafeArea()
         })
         .sheet(isPresented: $showingCropShapeList) {
-            CropShapeListView(cropShapeType: $cropShapeType, selectedType: $showingCropper)
+            // CropShapeListView writes cropShapeType before flipping selectedType,
+            // so the setter below sees the freshly chosen shape.
+            CropShapeListView(cropShapeType: $cropShapeType, selectedType: Binding(
+                get: { cropperOptions != nil },
+                set: { isSelected in
+                    if isSelected {
+                        cropperOptions = DeclarativeCropperOptions(cropShapeType: cropShapeType)
+                    }
+                }
+            ))
         }
         .sheet(isPresented: $showSourceTypeSelection) {
             SourceTypeSelectionView(showSourceTypeSelection: $showSourceTypeSelection, showCamera: $showCamera, showImagePicker: $showImagePicker)
@@ -78,10 +77,6 @@ struct ContentView: View {
     
     func reset() {
         cropShapeType = .rect
-        cropAspectRatio = .free
-        showsRotationControl = true
-        usesSlideDial = false
-        enablesPerspectiveCorrection = false
     }
     
     func createImageHolder() -> some View {
@@ -120,7 +115,7 @@ struct ContentView: View {
         VStack(alignment: .leading) {
             Spacer()
             Button("Normal Crop") {
-                showingCropper = true
+                cropperOptions = DeclarativeCropperOptions()
             }.font(.title)
             Button("Custom Toolbar (CropSession)") {
                 showingCustomToolbarCropper = true
@@ -129,20 +124,16 @@ struct ContentView: View {
                 showingCropShapeList = true
             }.font(.title)
             Button("Keep 1:1 ratio") {
-                cropAspectRatio = .fixed(1)
-                showingCropper = true
+                cropperOptions = DeclarativeCropperOptions(aspectRatio: .fixed(1))
             }.font(.title)
             Button("Hide Rotation Dial") {
-                showsRotationControl = false
-                showingCropper = true
+                cropperOptions = DeclarativeCropperOptions(showsRotationControl: false)
             }.font(.title)
             Button("Slide Dial") {
-                usesSlideDial = true
-                showingCropper = true
+                cropperOptions = DeclarativeCropperOptions(usesSlideDial: true)
             }.font(.title)
             Button("Perspective Correction") {
-                enablesPerspectiveCorrection = true
-                showingCropper = true
+                cropperOptions = DeclarativeCropperOptions(enablesPerspectiveCorrection: true)
             }.font(.title)
             Button("Restore Last Crop") {
                 showingRestorableCropper = true

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -9,21 +9,26 @@ import SwiftUI
 import Mantis
 
 struct ContentView: View {
+    // Mirrors the UIKit example's data flow: `image` always holds the full
+    // original; crop results only go to `croppedImage` for display, so every
+    // demo starts from the complete picture.
     @State private var image: UIImage? = UIImage(named: "sunflower")!
+    @State private var croppedImage: UIImage?
+    @State private var savedTransformation: Transformation?
+
     @State private var cropperOptions: DeclarativeCropperOptions?
     @State private var showingCustomToolbarCropper = false
     @State private var showingLegacyCropper = false
     @State private var showingCropShapeList = false
     @State private var cropShapeType: Mantis.CropShapeType = .rect
-    @State private var showingRestorableCropper = false
-    @State private var savedTransformation: Transformation?
     @State private var contentHeight: CGFloat = 0
-    
+
     @State private var showImagePicker = false
     @State private var showCamera = false
     @State private var showSourceTypeSelection = false
     @State private var sourceType: UIImagePickerController.SourceType?
-    
+    @State private var pickedImage: UIImage?
+
     @State private var transformation: Transformation?
     
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -34,21 +39,26 @@ struct ContentView: View {
             createFeatureDemoList()
         }
         .fullScreenCover(item: $cropperOptions, onDismiss: reset, content: { options in
-            DeclarativeCropperView(image: $image, options: options)
+            DeclarativeCropperView(image: $image,
+                                   croppedImage: $croppedImage,
+                                   savedTransformation: $savedTransformation,
+                                   options: options)
                 .ignoresSafeArea()
         })
-        .fullScreenCover(isPresented: $showingRestorableCropper, content: {
-            RestorableCropperDemoView(image: $image,
-                                      savedTransformation: $savedTransformation,
-                                      originalImage: UIImage(named: "sunflower")!)
-            .ignoresSafeArea()
-        })
         .fullScreenCover(isPresented: $showingCustomToolbarCropper, content: {
-            DeclarativeCropperDemoView(image: $image)
+            DeclarativeCropperDemoView(image: $image,
+                                       croppedImage: $croppedImage,
+                                       savedTransformation: $savedTransformation)
                 .ignoresSafeArea()
         })
         .fullScreenCover(isPresented: $showingLegacyCropper, content: {
-            ImageCropperWrapper(image: $image, transformation: $transformation)
+            // The legacy binding API replaces the bound image with the crop
+            // result by design, so hand it the displayed image and route the
+            // result to croppedImage — the original stays untouched.
+            ImageCropperWrapper(image: Binding(
+                get: { croppedImage ?? image },
+                set: { croppedImage = $0 }
+            ), transformation: $transformation)
                 .onDisappear(perform: reset)
                 .ignoresSafeArea()
         })
@@ -67,22 +77,32 @@ struct ContentView: View {
         .sheet(isPresented: $showSourceTypeSelection) {
             SourceTypeSelectionView(showSourceTypeSelection: $showSourceTypeSelection, showCamera: $showCamera, showImagePicker: $showImagePicker)
         }
-        .sheet(isPresented: $showCamera) {
-            CameraView(image: $image)
+        .sheet(isPresented: $showCamera, onDismiss: applyPickedImage) {
+            CameraView(image: $pickedImage)
         }
-        .sheet(isPresented: $showImagePicker) {
-            ImagePickerView(image: $image)
+        .sheet(isPresented: $showImagePicker, onDismiss: applyPickedImage) {
+            ImagePickerView(image: $pickedImage)
         }
     }
-    
+
     func reset() {
         cropShapeType = .rect
+    }
+
+    /// A saved transformation is only valid for the image it was created
+    /// from, so switching the original clears the derived state.
+    func applyPickedImage() {
+        guard let pickedImage = pickedImage else { return }
+        image = pickedImage
+        croppedImage = nil
+        savedTransformation = nil
+        self.pickedImage = nil
     }
     
     func createImageHolder() -> some View {
         VStack {
             Spacer()
-            Image(uiImage: image!)
+            Image(uiImage: croppedImage ?? image!)
                 .resizable().aspectRatio(contentMode: .fit)
                 .frame(width: 300, height: 300, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
             HStack {
@@ -92,6 +112,8 @@ struct ContentView: View {
                 .font(.title)
                 Button("Reset Image") {
                     image = UIImage(named: "sunflower")!
+                    croppedImage = nil
+                    savedTransformation = nil
                 }
                 .font(.title)
             }
@@ -115,7 +137,9 @@ struct ContentView: View {
         VStack(alignment: .leading) {
             Spacer()
             Button("Normal Crop") {
-                cropperOptions = DeclarativeCropperOptions()
+                // Like the UIKit example's normal entry: reopen restored to
+                // the previous crop state, cropping the full original image.
+                cropperOptions = DeclarativeCropperOptions(restoresLastTransformation: true)
             }.font(.title)
             Button("Custom Toolbar (CropSession)") {
                 showingCustomToolbarCropper = true
@@ -134,9 +158,6 @@ struct ContentView: View {
             }.font(.title)
             Button("Perspective Correction") {
                 cropperOptions = DeclarativeCropperOptions(enablesPerspectiveCorrection: true)
-            }.font(.title)
-            Button("Restore Last Crop") {
-                showingRestorableCropper = true
             }.font(.title)
             Button("Legacy Binding API") {
                 showingLegacyCropper = true

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -8,20 +8,15 @@
 import SwiftUI
 import Mantis
 
-public enum CropperType {
-    case normal
-    case noRotationDial
-    case noAttachedToolbar
-}
-
 struct ContentView: View {
     @State private var image: UIImage? = UIImage(named: "sunflower")!
     @State private var showingCropper = false
-    @State private var showingDeclarativeCropper = false
+    @State private var showingCustomToolbarCropper = false
+    @State private var showingLegacyCropper = false
     @State private var showingCropShapeList = false
     @State private var cropShapeType: Mantis.CropShapeType = .rect
-    @State private var presetFixedRatioType: Mantis.PresetFixedRatioType = .canUseMultiplePresetFixedRatio()
-    @State private var cropperType: CropperType = .normal
+    @State private var cropAspectRatio: CropAspectRatio = .free
+    @State private var showsRotationControl = true
     @State private var contentHeight: CGFloat = 0
     
     @State private var showImagePicker = false
@@ -38,17 +33,22 @@ struct ContentView: View {
             createImageHolder()
             createFeatureDemoList()
         }
-        .fullScreenCover(isPresented: $showingDeclarativeCropper, content: {
+        .fullScreenCover(isPresented: $showingCropper, content: {
+            DeclarativeCropperView(image: $image,
+                                   cropShapeType: cropShapeType,
+                                   aspectRatio: cropAspectRatio,
+                                   showsRotationControl: showsRotationControl)
+            .onDisappear(perform: reset)
+            .ignoresSafeArea()
+        })
+        .fullScreenCover(isPresented: $showingCustomToolbarCropper, content: {
             DeclarativeCropperDemoView(image: $image)
                 .ignoresSafeArea()
         })
-        .fullScreenCover(isPresented: $showingCropper, content: {
-            ImageCropperWrapper(image: $image,
-                                cropShapeType: $cropShapeType,
-                                presetFixedRatioType: $presetFixedRatioType,
-                                type: $cropperType, transformation: $transformation)
-            .onDisappear(perform: reset)
-            .ignoresSafeArea()
+        .fullScreenCover(isPresented: $showingLegacyCropper, content: {
+            ImageCropperWrapper(image: $image, transformation: $transformation)
+                .onDisappear(perform: reset)
+                .ignoresSafeArea()
         })
         .sheet(isPresented: $showingCropShapeList) {
             CropShapeListView(cropShapeType: $cropShapeType, selectedType: $showingCropper)
@@ -66,8 +66,8 @@ struct ContentView: View {
     
     func reset() {
         cropShapeType = .rect
-        presetFixedRatioType = .canUseMultiplePresetFixedRatio()
-        cropperType = .normal
+        cropAspectRatio = .free
+        showsRotationControl = true
     }
     
     func createImageHolder() -> some View {
@@ -108,23 +108,22 @@ struct ContentView: View {
             Button("Normal Crop") {
                 showingCropper = true
             }.font(.title)
-            Button("Declarative API (3.0)") {
-                showingDeclarativeCropper = true
+            Button("Custom Toolbar (CropSession)") {
+                showingCustomToolbarCropper = true
             }.font(.title)
             Button("Select crop shape") {
                 showingCropShapeList = true
             }.font(.title)
             Button("Keep 1:1 ratio") {
-                presetFixedRatioType = .alwaysUsingOnePresetFixedRatio(ratio: 1)
+                cropAspectRatio = .fixed(1)
                 showingCropper = true
             }.font(.title)
             Button("Hide Rotation Dial") {
-                cropperType = .noRotationDial
+                showsRotationControl = false
                 showingCropper = true
             }.font(.title)
-            Button("Hide Attached Toolbar") {
-                cropperType = .noAttachedToolbar
-                showingCropper = true
+            Button("Legacy Binding API") {
+                showingLegacyCropper = true
             }.font(.title)
             Spacer()
         }

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -17,6 +17,10 @@ struct ContentView: View {
     @State private var cropShapeType: Mantis.CropShapeType = .rect
     @State private var cropAspectRatio: CropAspectRatio = .free
     @State private var showsRotationControl = true
+    @State private var usesSlideDial = false
+    @State private var enablesPerspectiveCorrection = false
+    @State private var showingRestorableCropper = false
+    @State private var savedTransformation: Transformation?
     @State private var contentHeight: CGFloat = 0
     
     @State private var showImagePicker = false
@@ -37,8 +41,16 @@ struct ContentView: View {
             DeclarativeCropperView(image: $image,
                                    cropShapeType: cropShapeType,
                                    aspectRatio: cropAspectRatio,
-                                   showsRotationControl: showsRotationControl)
+                                   showsRotationControl: showsRotationControl,
+                                   usesSlideDial: usesSlideDial,
+                                   enablesPerspectiveCorrection: enablesPerspectiveCorrection)
             .onDisappear(perform: reset)
+            .ignoresSafeArea()
+        })
+        .fullScreenCover(isPresented: $showingRestorableCropper, content: {
+            RestorableCropperDemoView(image: $image,
+                                      savedTransformation: $savedTransformation,
+                                      originalImage: UIImage(named: "sunflower")!)
             .ignoresSafeArea()
         })
         .fullScreenCover(isPresented: $showingCustomToolbarCropper, content: {
@@ -68,6 +80,8 @@ struct ContentView: View {
         cropShapeType = .rect
         cropAspectRatio = .free
         showsRotationControl = true
+        usesSlideDial = false
+        enablesPerspectiveCorrection = false
     }
     
     func createImageHolder() -> some View {
@@ -121,6 +135,17 @@ struct ContentView: View {
             Button("Hide Rotation Dial") {
                 showsRotationControl = false
                 showingCropper = true
+            }.font(.title)
+            Button("Slide Dial") {
+                usesSlideDial = true
+                showingCropper = true
+            }.font(.title)
+            Button("Perspective Correction") {
+                enablesPerspectiveCorrection = true
+                showingCropper = true
+            }.font(.title)
+            Button("Restore Last Crop") {
+                showingRestorableCropper = true
             }.font(.title)
             Button("Legacy Binding API") {
                 showingLegacyCropper = true

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -17,6 +17,7 @@ public enum CropperType {
 struct ContentView: View {
     @State private var image: UIImage? = UIImage(named: "sunflower")!
     @State private var showingCropper = false
+    @State private var showingDeclarativeCropper = false
     @State private var showingCropShapeList = false
     @State private var cropShapeType: Mantis.CropShapeType = .rect
     @State private var presetFixedRatioType: Mantis.PresetFixedRatioType = .canUseMultiplePresetFixedRatio()
@@ -37,6 +38,10 @@ struct ContentView: View {
             createImageHolder()
             createFeatureDemoList()
         }
+        .fullScreenCover(isPresented: $showingDeclarativeCropper, content: {
+            DeclarativeCropperDemoView(image: $image)
+                .ignoresSafeArea()
+        })
         .fullScreenCover(isPresented: $showingCropper, content: {
             ImageCropperWrapper(image: $image,
                                 cropShapeType: $cropShapeType,
@@ -102,6 +107,9 @@ struct ContentView: View {
             Spacer()
             Button("Normal Crop") {
                 showingCropper = true
+            }.font(.title)
+            Button("Declarative API (3.0)") {
+                showingDeclarativeCropper = true
             }.font(.title)
             Button("Select crop shape") {
                 showingCropShapeList = true

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -9,6 +9,17 @@
 import Mantis
 import SwiftUI
 
+/// Shown when a cropper demo is presented without an image, instead of
+/// feeding a dummy zero-size UIImage() into ImageCropper.
+private func missingImagePlaceholder(presentationMode: Binding<PresentationMode>) -> some View {
+    VStack(spacing: 16) {
+        Text("No image to crop")
+        Button("Close") {
+            presentationMode.wrappedValue.dismiss()
+        }
+    }
+}
+
 /// Options for one presentation of the main-line cropper. Presented with
 /// `fullScreenCover(item:)` so the cover content is always built from this
 /// value — building it from separate @State vars risks the first presentation
@@ -34,11 +45,17 @@ struct DeclarativeCropperView: View {
     @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
-        makeCropper()
+        // The demo never presents without an image; keep the nil case explicit
+        // rather than feeding a dummy zero-size UIImage() into the cropper.
+        if let imageToCrop = image {
+            makeCropper(with: imageToCrop)
+        } else {
+            missingImagePlaceholder(presentationMode: presentationMode)
+        }
     }
 
-    private func makeCropper() -> ImageCropper {
-        var cropper = ImageCropper(image: image ?? UIImage())
+    private func makeCropper(with imageToCrop: UIImage) -> ImageCropper {
+        var cropper = ImageCropper(image: imageToCrop)
             .cropShape(options.cropShapeType)
             .onCrop { result in
                 image = result.croppedImage
@@ -131,7 +148,18 @@ struct DeclarativeCropperDemoView: View {
 
     var body: some View {
         NavigationView {
-            ImageCropper(image: image ?? UIImage(), session: session)
+            if let imageToCrop = image {
+                makeCropper(with: imageToCrop)
+            } else {
+                // Explicit nil handling: no cropper means no toolbar, so none
+                // of the session actions can be triggered without an image.
+                missingImagePlaceholder(presentationMode: presentationMode)
+            }
+        }
+    }
+
+    private func makeCropper(with imageToCrop: UIImage) -> some View {
+        ImageCropper(image: imageToCrop, session: session)
                 .aspectRatio(.free)
                 .builtInToolbarVisible(false)
                 .onCrop { result in
@@ -220,6 +248,5 @@ struct DeclarativeCropperDemoView: View {
                         }
                     }
                 }
-        }
     }
 }

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -1,0 +1,114 @@
+//
+//  DeclarativeCropperDemoView.swift
+//  MantisSwiftUIExample
+//
+//  Demonstrates the Mantis 3.0 declarative SwiftUI API:
+//  ImageCropper configured with modifiers, driven by an observable CropSession.
+//
+
+import Mantis
+import SwiftUI
+
+struct DeclarativeCropperDemoView: View {
+    @Binding var image: UIImage?
+
+    /// CropSession is an ObservableObject on iOS 15/16 and additionally
+    /// supports fine-grained Observation tracking on iOS 17+.
+    @StateObject private var session = CropSession()
+
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        NavigationView {
+            ImageCropper(image: image ?? UIImage(), session: session)
+                .aspectRatio(.free)
+                .builtInToolbarVisible(false)
+                .onCrop { result in
+                    image = result.croppedImage
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .onCancel {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItemGroup(placement: .navigationBarLeading) {
+                        Button {
+                            presentationMode.wrappedValue.dismiss()
+                        } label: {
+                            Image(systemName: "xmark")
+                        }
+                    }
+
+                    ToolbarItemGroup(placement: .navigationBarTrailing) {
+                        Button {
+                            session.undo()
+                        } label: {
+                            Image(systemName: "arrow.uturn.backward")
+                        }
+                        .disabled(!session.canUndo)
+
+                        Button {
+                            session.redo()
+                        } label: {
+                            Image(systemName: "arrow.uturn.forward")
+                        }
+                        .disabled(!session.canRedo)
+
+                        Button {
+                            session.reset()
+                        } label: {
+                            Image(systemName: "arrow.counterclockwise")
+                        }
+                        .disabled(!session.isResettable)
+
+                        Menu {
+                            Button {
+                                session.rotate(.clockwise)
+                            } label: {
+                                Label("Rotate Right", systemImage: "rotate.right")
+                            }
+
+                            Button {
+                                session.rotate(.counterClockwise)
+                            } label: {
+                                Label("Rotate Left", systemImage: "rotate.left")
+                            }
+
+                            Button {
+                                session.flip(.horizontal)
+                            } label: {
+                                Label("Flip Horizontally", systemImage: "arrow.left.and.right.righttriangle.left.righttriangle.right")
+                            }
+
+                            Button {
+                                session.flip(.vertical)
+                            } label: {
+                                Label("Flip Vertically", systemImage: "arrow.up.and.down.righttriangle.up.righttriangle.down")
+                            }
+
+                            Button {
+                                session.setAspectRatio(.fixed(16 / 9))
+                            } label: {
+                                Label("16:9 Ratio", systemImage: "aspectratio")
+                            }
+
+                            Button {
+                                session.setAspectRatio(.free)
+                            } label: {
+                                Label("Free Ratio", systemImage: "aspectratio.fill")
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                        }
+
+                        Button {
+                            session.crop()
+                        } label: {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+        }
+    }
+}

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -18,6 +18,8 @@ struct DeclarativeCropperView: View {
     let cropShapeType: Mantis.CropShapeType
     let aspectRatio: CropAspectRatio
     let showsRotationControl: Bool
+    var usesSlideDial = false
+    var enablesPerspectiveCorrection = false
 
     @Environment(\.presentationMode) var presentationMode
 
@@ -45,6 +47,62 @@ struct DeclarativeCropperView: View {
         if !showsRotationControl {
             cropper = cropper.configure { config in
                 config.cropViewConfig.showAttachedRotationControlView = false
+            }
+        }
+
+        if usesSlideDial {
+            cropper = cropper.configure { config in
+                config.cropViewConfig.builtInRotationControlViewType = .slideDial()
+            }
+        }
+
+        if enablesPerspectiveCorrection {
+            // Enables the horizontal/vertical skew correction modes; Mantis
+            // switches the rotation control to a slide dial with a type
+            // selector, matching the UIKit example's setup.
+            cropper = cropper.configure { config in
+                config.appearanceMode = .system
+                config.cropViewConfig.enablePerspectiveCorrection = true
+            }
+        }
+
+        return cropper
+    }
+}
+
+/// Demonstrates saving the crop parameters and restoring them later:
+/// the `Transformation` delivered by `onCrop` is kept and fed back through
+/// `presetTransformationType` the next time the cropper opens, so the user
+/// continues from exactly where the last crop left off.
+///
+/// The transformation is only meaningful for the image it was created from,
+/// so this demo always crops the same bundled original.
+struct RestorableCropperDemoView: View {
+    @Binding var image: UIImage?
+    @Binding var savedTransformation: Transformation?
+
+    let originalImage: UIImage
+
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        makeCropper()
+    }
+
+    private func makeCropper() -> ImageCropper {
+        var cropper = ImageCropper(image: originalImage)
+            .onCrop { result in
+                savedTransformation = result.transformation
+                image = result.croppedImage
+                presentationMode.wrappedValue.dismiss()
+            }
+            .onCancel {
+                presentationMode.wrappedValue.dismiss()
+            }
+
+        if let transformation = savedTransformation {
+            cropper = cropper.configure { config in
+                config.cropViewConfig.presetTransformationType = .presetInfo(info: transformation)
             }
         }
 

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -9,17 +9,27 @@
 import Mantis
 import SwiftUI
 
+/// Options for one presentation of the main-line cropper. Presented with
+/// `fullScreenCover(item:)` so the cover content is always built from this
+/// value — building it from separate @State vars risks the first presentation
+/// seeing values from before the button's state writes were committed, and
+/// the cropper applies its configuration only once at creation.
+struct DeclarativeCropperOptions: Identifiable {
+    let id = UUID()
+    var cropShapeType: Mantis.CropShapeType = .rect
+    var aspectRatio: CropAspectRatio = .free
+    var showsRotationControl = true
+    var usesSlideDial = false
+    var enablesPerspectiveCorrection = false
+}
+
 /// The main-line cropper of the example app, built on the declarative API.
 /// Shows the built-in Mantis toolbar and maps the feature-list options
 /// (crop shape, aspect ratio, rotation control) onto ImageCropper modifiers.
 struct DeclarativeCropperView: View {
     @Binding var image: UIImage?
 
-    let cropShapeType: Mantis.CropShapeType
-    let aspectRatio: CropAspectRatio
-    let showsRotationControl: Bool
-    var usesSlideDial = false
-    var enablesPerspectiveCorrection = false
+    let options: DeclarativeCropperOptions
 
     @Environment(\.presentationMode) var presentationMode
 
@@ -29,7 +39,7 @@ struct DeclarativeCropperView: View {
 
     private func makeCropper() -> ImageCropper {
         var cropper = ImageCropper(image: image ?? UIImage())
-            .cropShape(cropShapeType)
+            .cropShape(options.cropShapeType)
             .onCrop { result in
                 image = result.croppedImage
                 presentationMode.wrappedValue.dismiss()
@@ -40,23 +50,23 @@ struct DeclarativeCropperView: View {
 
         // Only apply an explicit ratio when one was requested; shapes like
         // circle already lock the ratio and a .free call would undo that.
-        if case .fixed(let ratio) = aspectRatio {
+        if case .fixed(let ratio) = options.aspectRatio {
             cropper = cropper.aspectRatio(.fixed(ratio))
         }
 
-        if !showsRotationControl {
+        if !options.showsRotationControl {
             cropper = cropper.configure { config in
                 config.cropViewConfig.showAttachedRotationControlView = false
             }
         }
 
-        if usesSlideDial {
+        if options.usesSlideDial {
             cropper = cropper.configure { config in
                 config.cropViewConfig.builtInRotationControlViewType = .slideDial()
             }
         }
 
-        if enablesPerspectiveCorrection {
+        if options.enablesPerspectiveCorrection {
             // Enables the horizontal/vertical skew correction modes; Mantis
             // switches the rotation control to a slide dial with a type
             // selector, matching the UIKit example's setup.

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -9,6 +9,49 @@
 import Mantis
 import SwiftUI
 
+/// The main-line cropper of the example app, built on the declarative API.
+/// Shows the built-in Mantis toolbar and maps the feature-list options
+/// (crop shape, aspect ratio, rotation control) onto ImageCropper modifiers.
+struct DeclarativeCropperView: View {
+    @Binding var image: UIImage?
+
+    let cropShapeType: Mantis.CropShapeType
+    let aspectRatio: CropAspectRatio
+    let showsRotationControl: Bool
+
+    @Environment(\.presentationMode) var presentationMode
+
+    var body: some View {
+        makeCropper()
+    }
+
+    private func makeCropper() -> ImageCropper {
+        var cropper = ImageCropper(image: image ?? UIImage())
+            .cropShape(cropShapeType)
+            .onCrop { result in
+                image = result.croppedImage
+                presentationMode.wrappedValue.dismiss()
+            }
+            .onCancel {
+                presentationMode.wrappedValue.dismiss()
+            }
+
+        // Only apply an explicit ratio when one was requested; shapes like
+        // circle already lock the ratio and a .free call would undo that.
+        if case .fixed(let ratio) = aspectRatio {
+            cropper = cropper.aspectRatio(.fixed(ratio))
+        }
+
+        if !showsRotationControl {
+            cropper = cropper.configure { config in
+                config.cropViewConfig.showAttachedRotationControlView = false
+            }
+        }
+
+        return cropper
+    }
+}
+
 struct DeclarativeCropperDemoView: View {
     @Binding var image: UIImage?
 

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -32,13 +32,21 @@ struct DeclarativeCropperOptions: Identifiable {
     var showsRotationControl = true
     var usesSlideDial = false
     var enablesPerspectiveCorrection = false
+    /// Reopen restored to the last saved crop state, like the UIKit
+    /// example's normal entry.
+    var restoresLastTransformation = false
 }
 
 /// The main-line cropper of the example app, built on the declarative API.
 /// Shows the built-in Mantis toolbar and maps the feature-list options
 /// (crop shape, aspect ratio, rotation control) onto ImageCropper modifiers.
 struct DeclarativeCropperView: View {
+    /// The full original image; never overwritten by a crop.
     @Binding var image: UIImage?
+    /// Where the crop result goes, for display back in the feature list.
+    @Binding var croppedImage: UIImage?
+    /// Saved on every crop so "Normal Crop" can restore the previous state.
+    @Binding var savedTransformation: Transformation?
 
     let options: DeclarativeCropperOptions
 
@@ -58,12 +66,19 @@ struct DeclarativeCropperView: View {
         var cropper = ImageCropper(image: imageToCrop)
             .cropShape(options.cropShapeType)
             .onCrop { result in
-                image = result.croppedImage
+                croppedImage = result.croppedImage
+                savedTransformation = result.transformation
                 presentationMode.wrappedValue.dismiss()
             }
             .onCancel {
                 presentationMode.wrappedValue.dismiss()
             }
+
+        if options.restoresLastTransformation, let transformation = savedTransformation {
+            cropper = cropper.configure { config in
+                config.cropViewConfig.presetTransformationType = .presetInfo(info: transformation)
+            }
+        }
 
         // Only apply an explicit ratio when one was requested; shapes like
         // circle already lock the ratio and a .free call would undo that.
@@ -97,48 +112,11 @@ struct DeclarativeCropperView: View {
     }
 }
 
-/// Demonstrates saving the crop parameters and restoring them later:
-/// the `Transformation` delivered by `onCrop` is kept and fed back through
-/// `presetTransformationType` the next time the cropper opens, so the user
-/// continues from exactly where the last crop left off.
-///
-/// The transformation is only meaningful for the image it was created from,
-/// so this demo always crops the same bundled original.
-struct RestorableCropperDemoView: View {
-    @Binding var image: UIImage?
-    @Binding var savedTransformation: Transformation?
-
-    let originalImage: UIImage
-
-    @Environment(\.presentationMode) var presentationMode
-
-    var body: some View {
-        makeCropper()
-    }
-
-    private func makeCropper() -> ImageCropper {
-        var cropper = ImageCropper(image: originalImage)
-            .onCrop { result in
-                savedTransformation = result.transformation
-                image = result.croppedImage
-                presentationMode.wrappedValue.dismiss()
-            }
-            .onCancel {
-                presentationMode.wrappedValue.dismiss()
-            }
-
-        if let transformation = savedTransformation {
-            cropper = cropper.configure { config in
-                config.cropViewConfig.presetTransformationType = .presetInfo(info: transformation)
-            }
-        }
-
-        return cropper
-    }
-}
-
 struct DeclarativeCropperDemoView: View {
+    /// The full original image; never overwritten by a crop.
     @Binding var image: UIImage?
+    @Binding var croppedImage: UIImage?
+    @Binding var savedTransformation: Transformation?
 
     /// CropSession is an ObservableObject on iOS 15/16 and additionally
     /// supports fine-grained Observation tracking on iOS 17+.
@@ -163,7 +141,8 @@ struct DeclarativeCropperDemoView: View {
                 .aspectRatio(.free)
                 .builtInToolbarVisible(false)
                 .onCrop { result in
-                    image = result.croppedImage
+                    croppedImage = result.croppedImage
+                    savedTransformation = result.transformation
                     presentationMode.wrappedValue.dismiss()
                 }
                 .onCancel {

--- a/SwiftUIExample/MantisSwiftUIExample/ImageCropperWrapper.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ImageCropperWrapper.swift
@@ -9,15 +9,14 @@ import Mantis
 import SwiftUI
 
 /**
- * A SwiftUI wrapper that provides different configurations for the Mantis image cropper.
- * This view adapts to different cropper types and provides a convenient API for
- * integrating the Mantis image cropping functionality into SwiftUI views.
+ * Demonstrates the legacy binding-based API (`ImageCropperView` driven by a
+ * `CropAction` binding), kept as a migration reference for Mantis 2.x users.
+ *
+ * New code should prefer the declarative `ImageCropper` + `CropSession` API;
+ * see DeclarativeCropperDemoView for the equivalent of this screen.
  */
 struct ImageCropperWrapper: View {
     @Binding var image: UIImage?
-    @Binding var cropShapeType: Mantis.CropShapeType
-    @Binding var presetFixedRatioType: Mantis.PresetFixedRatioType
-    @Binding var type: CropperType
     @Binding var transformation: Transformation?
     @State private var action: CropAction?
 
@@ -25,19 +24,9 @@ struct ImageCropperWrapper: View {
 
     var body: some View {
         NavigationView {
-            ZStack {
-                switch type {
-                case .normal:
-                    makeNormalImageCropper()
-                case .noRotationDial:
-                    makeImageCropperHidingRotationDial()
-                case .noAttachedToolbar:
-                    makeImageCropperWithoutAttachedToolbar()
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .if(type == .noAttachedToolbar, transform: { view in
-                view.toolbar {
+            makeImageCropperWithoutAttachedToolbar()
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
                     ToolbarItemGroup(placement: .navigationBarLeading) {
                         Button(
                             action: {
@@ -121,43 +110,11 @@ struct ImageCropperWrapper: View {
                         )
                     }
                 }
-            })
         }
     }
 }
 
 extension ImageCropperWrapper {
-    func makeNormalImageCropper() -> some View {
-        var config = Mantis.Config()
-        config.cropViewConfig.cropShapeType = cropShapeType
-        config.presetFixedRatioType = presetFixedRatioType
-
-        return ImageCropperView(
-            config: config,
-            image: $image,
-            transformation: $transformation,
-            cropInfo: .constant(nil),
-            onDismiss: {
-                presentationMode.wrappedValue.dismiss()
-            }
-        )
-    }
-
-    func makeImageCropperHidingRotationDial() -> some View {
-        var config = Mantis.Config()
-        config.cropViewConfig.showAttachedRotationControlView = false
-
-        return ImageCropperView(
-            config: config,
-            image: $image,
-            transformation: $transformation,
-            cropInfo: .constant(nil),
-            onDismiss: {
-                presentationMode.wrappedValue.dismiss()
-            }
-        )
-    }
-
     func makeImageCropperWithoutAttachedToolbar() -> some View {
         var config = Mantis.Config()
         config.showAttachedCropToolbar = false
@@ -173,17 +130,5 @@ extension ImageCropperWrapper {
                 presentationMode.wrappedValue.dismiss()
             }
         )
-    }
-}
-
-extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool,
-                             transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
     }
 }

--- a/SwiftUIExample/Podfile.lock
+++ b/SwiftUIExample/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Mantis (2.24.0)
+  - Mantis (2.31.2)
 
 DEPENDENCIES:
   - Mantis (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Mantis: 622ced3fe2470e18b1afbd6736724d9ff2dc539e
+  Mantis: f4a0a54488a662ea3e9c730d5135544ff193d449
 
 PODFILE CHECKSUM: b22a0202a3162df1f336549fb492f179aac13f6c
 

--- a/Tests/MantisTests/CropSessionTests.swift
+++ b/Tests/MantisTests/CropSessionTests.swift
@@ -1,0 +1,167 @@
+//
+//  CropSessionTests.swift
+//  MantisTests
+//
+//  Created for Mantis 3.0.
+//
+
+import XCTest
+import Combine
+#if canImport(Observation)
+import Observation
+#endif
+@testable import Mantis
+
+final class CropSessionTests: XCTestCase {
+
+    var session: CropSession!
+    var cancellables: Set<AnyCancellable> = []
+
+    override func setUpWithError() throws {
+        session = CropSession()
+        cancellables = []
+    }
+
+    func testInitialState() {
+        XCTAssertFalse(session.canUndo)
+        XCTAssertFalse(session.canRedo)
+        XCTAssertFalse(session.isResettable)
+        XCTAssertNil(session.transformation)
+        XCTAssertNil(session.cropViewController)
+    }
+
+    func testStateMutationIsObservable() {
+        var changeCount = 0
+        session.objectWillChange
+            .sink { changeCount += 1 }
+            .store(in: &cancellables)
+
+        session.canUndo = true
+        session.canRedo = true
+        session.isResettable = true
+
+        XCTAssertTrue(session.canUndo)
+        XCTAssertTrue(session.canRedo)
+        XCTAssertTrue(session.isResettable)
+        XCTAssertEqual(changeCount, 3)
+
+        // Setting the same value again must not publish a change.
+        session.canUndo = true
+        XCTAssertEqual(changeCount, 3)
+    }
+
+    func testTransformationUpdateIsObservable() {
+        var changeCount = 0
+        session.objectWillChange
+            .sink { changeCount += 1 }
+            .store(in: &cancellables)
+
+        let transformation = Transformation(offset: CGPoint(x: 1, y: 2),
+                                            rotation: 0.5,
+                                            scale: 2,
+                                            isManuallyZoomed: true,
+                                            initialMaskFrame: .zero,
+                                            maskFrame: .zero,
+                                            cropWorkbenchViewBounds: .zero,
+                                            horizontallyFlipped: false,
+                                            verticallyFlipped: false)
+        session.transformation = transformation
+
+        XCTAssertEqual(session.transformation, transformation)
+        XCTAssertEqual(changeCount, 1)
+
+        session.transformation = transformation
+        XCTAssertEqual(changeCount, 1)
+    }
+
+    func testObservationTrackingFiresOniOS17() throws {
+#if canImport(Observation)
+        guard #available(iOS 17.0, macCatalyst 17.0, *) else {
+            throw XCTSkip("Observation requires iOS 17")
+        }
+
+        var changeFired = false
+        withObservationTracking {
+            _ = session.canUndo
+        } onChange: {
+            changeFired = true
+        }
+
+        session.canRedo = true
+        XCTAssertFalse(changeFired, "Tracking must be per-property, not object-wide")
+
+        session.canUndo = true
+        XCTAssertTrue(changeFired)
+#else
+        throw XCTSkip("Observation framework not available")
+#endif
+    }
+
+    func testActionsWithoutAttachedCropperAreNoOps() {
+        // None of these may crash when the session is not attached.
+        session.rotate()
+        session.rotate(.counterClockwise)
+        session.flip()
+        session.flip(.vertical)
+        session.crop()
+        session.undo()
+        session.redo()
+        session.reset()
+        session.setAspectRatio(.fixed(16 / 9))
+        session.setAspectRatio(.free)
+    }
+
+    func testAttachResetsState() {
+        session.canUndo = true
+        session.canRedo = true
+        session.isResettable = true
+
+        let cropViewController = CropViewController()
+        session.attach(to: cropViewController)
+
+        XCTAssertTrue(session.cropViewController === cropViewController)
+        XCTAssertFalse(session.canUndo)
+        XCTAssertFalse(session.canRedo)
+        XCTAssertFalse(session.isResettable)
+    }
+}
+
+final class ImageCropperModifierTests: XCTestCase {
+
+    private let image = UIImage()
+
+    func testCropShapeModifier() {
+        let cropper = ImageCropper(image: image).cropShape(.circle)
+
+        XCTAssertEqual(cropper.config.cropViewConfig.cropShapeType, .circle())
+        // Circle implies a locked 1:1 ratio, mirroring CropViewController's behavior.
+        guard case .alwaysUsingOnePresetFixedRatio(let ratio) = cropper.config.presetFixedRatioType else {
+            return XCTFail("Expected a fixed 1:1 ratio for circle shape")
+        }
+        XCTAssertEqual(ratio, 1)
+    }
+
+    func testAspectRatioModifier() {
+        let fixed = ImageCropper(image: image).aspectRatio(.fixed(16 / 9))
+        guard case .alwaysUsingOnePresetFixedRatio(let ratio) = fixed.config.presetFixedRatioType else {
+            return XCTFail("Expected a fixed ratio")
+        }
+        XCTAssertEqual(ratio, 16.0 / 9.0, accuracy: 1e-9)
+
+        let free = fixed.aspectRatio(.free)
+        guard case .canUseMultiplePresetFixedRatio = free.config.presetFixedRatioType else {
+            return XCTFail("Expected a free ratio")
+        }
+    }
+
+    func testToolbarAndAppearanceAndConfigureModifiers() {
+        let cropper = ImageCropper(image: image)
+            .builtInToolbarVisible(false)
+            .appearance(.system)
+            .configure { $0.enableUndoRedo = true }
+
+        XCTAssertFalse(cropper.config.showAttachedCropToolbar)
+        XCTAssertEqual(cropper.config.appearanceMode, .system)
+        XCTAssertTrue(cropper.config.enableUndoRedo)
+    }
+}

--- a/Tests/MantisTests/TransformStackTests.swift
+++ b/Tests/MantisTests/TransformStackTests.swift
@@ -13,7 +13,7 @@ final class TransformStackTests: XCTestCase {
     var cropVC: CropViewController!
     var cropView: CropView!
     var cropViewModel: CropViewModelProtocol = CropViewModel(cropViewPadding: 0, hotAreaUnit: 0)
-    
+
     private func createCropView(with image: UIImage = UIImage(),
                                 cropViewConfig: CropViewConfig = CropViewConfig(),
                                 viewModel: CropViewModelProtocol) -> CropView {
@@ -25,64 +25,84 @@ final class TransformStackTests: XCTestCase {
                  cropWorkbenchView: FakeCropWorkbenchView(frame: .zero),
                  cropMaskViewManager: FakeCropMaskViewManager())
     }
-    
-    override func setUpWithError() throws {
-        
+
+    private func createCropViewController() -> CropViewController {
         var config = Config()
         config.enableUndoRedo = true
-        cropView = createCropView(cropViewConfig: config.cropViewConfig, viewModel: cropViewModel)
-        cropVC = CropViewController(config: config)
-        cropVC.cropView = cropView
-        
-        TransformStack.shared.transformDelegate = cropVC
-        TransformStack.shared.reset()
-        XCTAssertEqual(TransformStack.shared.top, 0)
+        let cropViewController = CropViewController(config: config)
+        cropViewController.cropView = createCropView(cropViewConfig: config.cropViewConfig, viewModel: cropViewModel)
+        cropViewController.transformStack.transformDelegate = cropViewController
+        return cropViewController
     }
-    
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+
+    override func setUpWithError() throws {
+        cropVC = createCropViewController()
+        cropView = (cropVC.cropView as? CropView)
+        XCTAssertEqual(cropVC.transformStack.top, 0)
     }
-    
+
     func testApplyRecords() {
+        let stack = cropVC.transformStack
+
         var previousState = cropView.makeCropState()
         var currentState = cropView.makeCropState()
-        
-        TransformStack.shared.pushTransformRecordOntoStack(transformType: .transform, 
-                                                           previous: previousState,
-                                                           current: currentState,
-                                                           userGenerated: true)
-        XCTAssertEqual(TransformStack.shared.top, 1)
-        
+
+        stack.pushTransformRecordOntoStack(transformType: .transform,
+                                           previous: previousState,
+                                           current: currentState,
+                                           userGenerated: true)
+        XCTAssertEqual(stack.top, 1)
+
         previousState = cropView.makeCropState()
         currentState = cropView.makeCropState()
-        
-        TransformStack.shared.pushTransformRecordOntoStack(transformType: .resetTransforms,
+
+        stack.pushTransformRecordOntoStack(transformType: .resetTransforms,
+                                           previous: previousState,
+                                           current: currentState,
+                                           userGenerated: true)
+
+        XCTAssertEqual(stack.top, 2)
+        stack.popTransformStack()
+        XCTAssertEqual(stack.top, 1)
+        stack.popTransformStack()
+        XCTAssertEqual(stack.top, 0)
+        stack.popTransformStack()
+        XCTAssertEqual(stack.top, 0)
+    }
+
+    func testStacksAreIndependentAcrossControllers() {
+        let otherCropVC = createCropViewController()
+
+        XCTAssertFalse(cropVC.transformStack === otherCropVC.transformStack)
+
+        let previousState = cropView.makeCropState()
+        let currentState = cropView.makeCropState()
+
+        cropVC.transformStack.pushTransformRecordOntoStack(transformType: .transform,
                                                            previous: previousState,
                                                            current: currentState,
                                                            userGenerated: true)
-        
-        XCTAssertEqual(TransformStack.shared.top, 2)
-        TransformStack.shared.popTransformStack()
-        XCTAssertEqual(TransformStack.shared.top, 1)
-        TransformStack.shared.popTransformStack()
-        XCTAssertEqual(TransformStack.shared.top, 0)
-        TransformStack.shared.popTransformStack()
-        XCTAssertEqual(TransformStack.shared.top, 0)
-    }
-    
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+
+        XCTAssertEqual(cropVC.transformStack.top, 1)
+        // A second concurrent crop session must not see the first session's records.
+        XCTAssertEqual(otherCropVC.transformStack.top, 0)
+
+        otherCropVC.transformStack.reset()
+        XCTAssertEqual(cropVC.transformStack.top, 1)
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
+    func testUndoManagersAreIndependentAcrossControllers() {
+        let otherCropVC = createCropViewController()
 
+        let previousState = cropView.makeCropState()
+        let currentState = cropView.makeCropState()
+
+        cropVC.transformStack.pushTransformRecordOntoStack(transformType: .transform,
+                                                           previous: previousState,
+                                                           current: currentState,
+                                                           userGenerated: true)
+
+        XCTAssertTrue(cropVC.getUndoManager().canUndo)
+        XCTAssertFalse(otherCropVC.getUndoManager().canUndo)
+    }
 }


### PR DESCRIPTION
## Summary

Mantis 3.0's new SwiftUI API, plus the architectural unblock it needs.

### 1. `CropSession` — observable session state (new)

- Observable properties: `canUndo`, `canRedo`, `isResettable`, and the live `transformation`.
- Plain methods instead of enum-binding actions: `rotate(_:)`, `flip(_:)`, `crop()`, `undo()`, `redo()`, `reset()`, `setAspectRatio(_:)`. All are safe no-ops when unattached.
- **iOS 17+**: participates in the Observation framework (fine-grained, per-property tracking) via a manually bridged `ObservationRegistrar` behind availability checks. **iOS 15/16**: behaves as a plain `ObservableObject`. Single type, both worlds.

### 2. `ImageCropper` — declarative SwiftUI view (new)

```swift
ImageCropper(image: image, session: session)
    .cropShape(.circle)
    .aspectRatio(.fixed(16/9))
    .builtInToolbarVisible(false)
    .onCrop { result in croppedImage = result.croppedImage }
```

- Modifiers: `.cropShape`, `.aspectRatio`, `.builtInToolbarVisible`, `.appearance`, `.configure { $0... }` (full-`Config` escape hatch), `.onCrop`, `.onCancel`, `.onCropFailed`.
- Attaching a `CropSession` enables undo/redo automatically.
- Added bare-case conveniences (`.circle`, `.ellipse`, `.diamond`, `.heart`) so `.cropShape(.circle)` compiles without parentheses.
- The existing binding-based `ImageCropperView` is untouched for backward compatibility.

### 3. `TransformStack.shared` singleton removed (fix)

The shared stack meant two concurrent crop sessions (iPad multi-window / multiple scenes) polluted each other's undo history. Now:

- Each `CropViewController` owns its own `TransformStack`; `TransformRecord` gets its stack injected (weak — records are retained by the controller-owned `UndoManager`, so lifetimes match).
- The `NSUndoManagerCheckpoint` observer is scoped to the session's own `UndoManager` instead of `object: nil`, so checkpoints from other sessions no longer trigger foreign state refreshes.
- Fixes a latent wiring bug: `config`'s `didSet` never fires when set in `init`, so the `Mantis.cropViewController(image:config:)` factory path never attached the transform delegate. `viewDidLoad` now wires it up.

## Tests

- `TransformStackTests` migrated off the singleton, plus two new isolation tests: independent stacks and independent undo managers across two controllers.
- New `CropSessionTests`: initial state, change-notification dedup, iOS 17 `withObservationTracking` fires per-property, unattached actions are no-ops, attach resets state.
- New `ImageCropperModifierTests`: modifier → `Mantis.Config` mapping.
- Full suite passes on iPhone 16 Pro simulator; SwiftLint clean; new files registered in `Mantis.xcodeproj` for the Carthage build path.

## Notes

- Declarative modifiers are applied once when the underlying controller is created (no live config diffing on re-render); runtime ratio changes go through `session.setAspectRatio(_:)`.
- README documents the new API; CHANGELOG is left to release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a SwiftUI declarative image cropper (`ImageCropper`) with crop shape, aspect ratio, built-in toolbar control, appearance, and callback hooks.
  * Introduced `CropSession` for live transformation state plus rotate/flip/crop/undo/redo/reset and aspect-ratio updates.
  * Added `CropResult` for delivering the cropped image, transformation, and crop info.
* **Bug Fixes**
  * Improved undo/redo behavior by scoping crop history to the active session/controller.
* **Documentation**
  * Updated README with a new “Declarative API (Mantis 3.0+)” section and modifier guidance.
* **Tests**
  * Added `CropSession` tests and updated `TransformStack` tests for per-instance behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->