### PR TITLE
feat: make CropInfo conform to Codable for cross-session crop persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 -----
 
+## [Unreleased]
+
+
+### Features
+
+* make `CropInfo` conform to `Codable` so a crop can be persisted and restored across app sessions — including rotated, fixed-ratio, perspective-skewed, and large-image crops. The opaque view-reconstruction state is encoded alongside the public fields, so a decoded `CropInfo` re-crops identically to the same-session value ([#536](https://www.github.com/guoyingtao/Mantis/issues/536)). This is additive and source compatible; if you previously added your own `extension CropInfo: Codable` as a workaround, remove it after upgrading to avoid a duplicate-conformance error.
+
 ## [3.0.0](https://www.github.com/guoyingtao/Mantis/compare/v2.31.2...v3.0.0) (2026-07-06)
 
 

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		97FA9A852BAFA570001E67D9 /* TransformStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97FA9A842BAFA570001E67D9 /* TransformStackTests.swift */; };
 		A1A1A1A1000000000000AA02 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */; };
 		AA00000000000000000000A1 /* CICropEquivalenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000A2 /* CICropEquivalenceTests.swift */; };
+		AA000000000000000000CDA1 /* CropInfoCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CDA2 /* CropInfoCodableTests.swift */; };
 		AA00000000000000000000B1 /* PerspectiveTransformHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */; };
 		AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000F2 /* SkewPositioningTests.swift */; };
 		AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000C2 /* GeometryHelperTests.swift */; };
@@ -235,6 +236,7 @@
 		97FA9A842BAFA570001E67D9 /* TransformStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformStackTests.swift; sourceTree = "<group>"; };
 		A1A1A1A1000000000000AA01 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		AA00000000000000000000A2 /* CICropEquivalenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CICropEquivalenceTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000CDA2 /* CropInfoCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropInfoCodableTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerspectiveTransformHelperTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000F2 /* SkewPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkewPositioningTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000C2 /* GeometryHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryHelperTests.swift; sourceTree = "<group>"; };
@@ -563,6 +565,7 @@
 				97FA9A842BAFA570001E67D9 /* TransformStackTests.swift */,
 				3A0C501E2E1B00010063EE05 /* CropSessionTests.swift */,
 				AA00000000000000000000A2 /* CICropEquivalenceTests.swift */,
+				AA000000000000000000CDA2 /* CropInfoCodableTests.swift */,
 				AA00000000000000000000B2 /* PerspectiveTransformHelperTests.swift */,
 				AA00000000000000000000F2 /* SkewPositioningTests.swift */,
 				AA00000000000000000000C2 /* GeometryHelperTests.swift */,
@@ -810,6 +813,7 @@
 				97FA9A852BAFA570001E67D9 /* TransformStackTests.swift in Sources */,
 				3A0C501F2E1B00010063EE06 /* CropSessionTests.swift in Sources */,
 				AA00000000000000000000A1 /* CICropEquivalenceTests.swift in Sources */,
+				AA000000000000000000CDA1 /* CropInfoCodableTests.swift in Sources */,
 				AA00000000000000000000B1 /* PerspectiveTransformHelperTests.swift in Sources */,
 				AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */,
 				AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -318,6 +318,34 @@ Please use the transformation information obtained previously from delegate meth
 </details>
 
 <details>
+<summary><strong>Persisting and restoring crops (<code>Codable</code>) 🆕</strong></summary>
+
+As of **Mantis 3.1**, `CropInfo` conforms to `Codable`, so you can save a user's exact crop and reproduce it offline in a later session — including rotated, fixed-ratio, perspective-skewed, and large-image crops.
+
+```swift
+// Save the CropInfo delivered by the delegate (or CropResult.cropInfo in SwiftUI).
+func cropViewControllerDidCrop(_ cropViewController: CropViewController,
+                               cropped: UIImage,
+                               transformation: Transformation,
+                               cropInfo: CropInfo) {
+    let data = try? JSONEncoder().encode(cropInfo)
+    // ...persist `data` (UserDefaults, a file, a database, etc.)
+}
+
+// Later — even in a new app session — re-crop the original image offline, no UI:
+let cropInfo = try JSONDecoder().decode(CropInfo.self, from: data)
+let recropped = Mantis.crop(image: originalImage, by: cropInfo)
+```
+
+* A decoded `CropInfo` crops **identically** to the same-session value: the opaque view-reconstruction state needed by the perspective-skew and `maxImagePixelCount` (large-image) paths is encoded alongside the public fields.
+* **Persist a `CropInfo` that Mantis produced** (from the delegate or `getCropInfo()`). A `CropInfo` you build by hand via the public `init` carries no view-reconstruction state, so the perspective and large-image paths still return `nil` for it — exactly as before.
+* If you only need to reopen the editor at the previous state (rather than crop offline), persisting the `Transformation` and restoring it via `presetTransformationType = .presetInfo(info:)` remains the lighter option.
+
+> **Compatibility:** adding `Codable` is purely additive — existing code needs no changes. The one exception: if you previously wrote your own `extension CropInfo: Codable` as a workaround, remove it after upgrading to avoid a duplicate-conformance error. The encoded JSON mirrors `CropInfo`'s fields, so treat versioning of your own persisted data as your app's responsibility.
+
+</details>
+
+<details>
 <summary><strong>Undo/Redo Support</strong></summary>
 
 * Mantis offers full support for Undo, Redo, Revert to Original in both iOS and Catalyst.

--- a/Sources/Mantis/CropData.swift
+++ b/Sources/Mantis/CropData.swift
@@ -98,7 +98,7 @@ public struct Transformation: Equatable, Sendable {
     }
 }
 
-public struct CropRegion: Equatable, Sendable {
+public struct CropRegion: Equatable, Sendable, Codable {
     public var topLeft: CGPoint
     public var topRight: CGPoint
     public var bottomLeft: CGPoint
@@ -122,7 +122,7 @@ public struct CropRegion: Equatable, Sendable {
     }
 }
 
-public struct CropInfo: Sendable {
+public struct CropInfo: Sendable, Codable {
     public var translation: CGPoint
     public var rotation: CGFloat
     public var scaleX: CGFloat
@@ -184,6 +184,87 @@ extension CropInfo {
         /// perspective crop path instead of reconstructing it from decomposed
         /// rotation / scale values.
         var scrollViewTransform: CGAffineTransform
+    }
+}
+
+/// `Codable` support so a `CropInfo` (including the internal view-reconstruction
+/// state needed for perspective / large-image crops) can be persisted and
+/// restored across app sessions. `CropInfo` and `CropRegion` get synthesized
+/// conformances; `ViewReconstruction` needs a manual one because `CATransform3D`
+/// and `CGAffineTransform` are not `Codable`. Their coefficients are boxed into
+/// private `Codable` structs rather than adding `Codable` conformances to the
+/// CoreGraphics/QuartzCore types themselves — a library-level retroactive
+/// conformance there would clash if the host app (or another dependency) added
+/// the same one.
+extension CropInfo.ViewReconstruction: Codable {
+    // swiftlint:disable identifier_name
+    /// The six coefficients of a `CGAffineTransform`.
+    private struct AffineTransformBox: Codable {
+        var a, b, c, d, tx, ty: CGFloat
+
+        init(_ transform: CGAffineTransform) {
+            a = transform.a
+            b = transform.b
+            c = transform.c
+            d = transform.d
+            tx = transform.tx
+            ty = transform.ty
+        }
+
+        var transform: CGAffineTransform {
+            CGAffineTransform(a: a, b: b, c: c, d: d, tx: tx, ty: ty)
+        }
+    }
+
+    /// The sixteen coefficients of a `CATransform3D`.
+    private struct Transform3DBox: Codable {
+        var m11, m12, m13, m14: CGFloat
+        var m21, m22, m23, m24: CGFloat
+        var m31, m32, m33, m34: CGFloat
+        var m41, m42, m43, m44: CGFloat
+
+        init(_ transform: CATransform3D) {
+            m11 = transform.m11; m12 = transform.m12; m13 = transform.m13; m14 = transform.m14
+            m21 = transform.m21; m22 = transform.m22; m23 = transform.m23; m24 = transform.m24
+            m31 = transform.m31; m32 = transform.m32; m33 = transform.m33; m34 = transform.m34
+            m41 = transform.m41; m42 = transform.m42; m43 = transform.m43; m44 = transform.m44
+        }
+
+        var transform: CATransform3D {
+            var result = CATransform3DIdentity
+            result.m11 = m11; result.m12 = m12; result.m13 = m13; result.m14 = m14
+            result.m21 = m21; result.m22 = m22; result.m23 = m23; result.m24 = m24
+            result.m31 = m31; result.m32 = m32; result.m33 = m33; result.m34 = m34
+            result.m41 = m41; result.m42 = m42; result.m43 = m43; result.m44 = m44
+            return result
+        }
+    }
+    // swiftlint:enable identifier_name
+
+    private enum CodingKeys: String, CodingKey {
+        case skewSublayerTransform
+        case scrollContentOffset
+        case scrollBoundsSize
+        case imageContainerFrame
+        case scrollViewTransform
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        skewSublayerTransform = try container.decode(Transform3DBox.self, forKey: .skewSublayerTransform).transform
+        scrollContentOffset = try container.decode(CGPoint.self, forKey: .scrollContentOffset)
+        scrollBoundsSize = try container.decode(CGSize.self, forKey: .scrollBoundsSize)
+        imageContainerFrame = try container.decode(CGRect.self, forKey: .imageContainerFrame)
+        scrollViewTransform = try container.decode(AffineTransformBox.self, forKey: .scrollViewTransform).transform
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(Transform3DBox(skewSublayerTransform), forKey: .skewSublayerTransform)
+        try container.encode(scrollContentOffset, forKey: .scrollContentOffset)
+        try container.encode(scrollBoundsSize, forKey: .scrollBoundsSize)
+        try container.encode(imageContainerFrame, forKey: .imageContainerFrame)
+        try container.encode(AffineTransformBox(scrollViewTransform), forKey: .scrollViewTransform)
     }
 }
 

--- a/Tests/MantisTests/CropInfoCodableTests.swift
+++ b/Tests/MantisTests/CropInfoCodableTests.swift
@@ -1,0 +1,297 @@
+//
+//  CropInfoCodableTests.swift
+//  MantisTests
+//
+//  Verifies that CropInfo round-trips through Codable so crop settings can be
+//  persisted and restored across app sessions (see issue #536), including the
+//  internal ViewReconstruction state needed for perspective / large-image crops.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CropInfoCodableTests: XCTestCase {
+
+    // MARK: - Fixtures
+
+    /// A plain crop with no rotation, skew or captured view state.
+    private func makeStandardCropInfo() -> CropInfo {
+        CropInfo(
+            translation: CGPoint(x: 12, y: -34),
+            rotation: 0,
+            scaleX: 1,
+            scaleY: 1,
+            cropSize: CGSize(width: 200, height: 160),
+            imageViewSize: CGSize(width: 500, height: 400),
+            cropRegion: CropRegion(topLeft: CGPoint(x: 10, y: 20),
+                                   topRight: CGPoint(x: 210, y: 20),
+                                   bottomLeft: CGPoint(x: 10, y: 180),
+                                   bottomRight: CGPoint(x: 210, y: 180))
+        )
+    }
+
+    /// A fixed-ratio crop (square crop box) that has been zoomed and flipped.
+    private func makeFixedRatioCropInfo() -> CropInfo {
+        CropInfo(
+            translation: CGPoint(x: -5, y: 7),
+            rotation: 0,
+            scaleX: -1.5,
+            scaleY: 1.5,
+            cropSize: CGSize(width: 300, height: 300),
+            imageViewSize: CGSize(width: 600, height: 400),
+            cropRegion: CropRegion(topLeft: CGPoint(x: 0, y: 0),
+                                   topRight: CGPoint(x: 300, y: 0),
+                                   bottomLeft: CGPoint(x: 0, y: 300),
+                                   bottomRight: CGPoint(x: 300, y: 300))
+        )
+    }
+
+    /// A rotated crop with captured (identity-skew) view-reconstruction state.
+    private func makeRotatedCropInfo() -> CropInfo {
+        var info = CropInfo(
+            translation: CGPoint(x: 3, y: 9),
+            rotation: .pi / 6,
+            scaleX: 1.2,
+            scaleY: 1.2,
+            cropSize: CGSize(width: 250, height: 180),
+            imageViewSize: CGSize(width: 500, height: 400),
+            cropRegion: CropRegion(topLeft: CGPoint(x: 40, y: 30),
+                                   topRight: CGPoint(x: 290, y: 55),
+                                   bottomLeft: CGPoint(x: 15, y: 210),
+                                   bottomRight: CGPoint(x: 265, y: 235))
+        )
+        info.viewReconstruction = CropInfo.ViewReconstruction(
+            skewSublayerTransform: CATransform3DIdentity,
+            scrollContentOffset: CGPoint(x: 100, y: 80),
+            scrollBoundsSize: CGSize(width: 250, height: 180),
+            imageContainerFrame: CGRect(x: 0, y: 0, width: 600, height: 480),
+            scrollViewTransform: CGAffineTransform(rotationAngle: .pi / 6)
+        )
+        return info
+    }
+
+    /// A perspective-skewed crop whose reconstruction carries a non-identity
+    /// 3D sublayer transform and a rotated+flipped scroll-view transform.
+    private func makePerspectiveCropInfo() -> CropInfo {
+        var skew = CATransform3DIdentity
+        skew.m34 = -1.0 / 500.0
+        skew = CATransform3DRotate(skew, .pi / 9, 0, 1, 0)
+        skew = CATransform3DTranslate(skew, 4, -6, 0)
+        skew = CATransform3DScale(skew, 1.1, 0.95, 1)
+
+        var info = CropInfo(
+            translation: CGPoint(x: -8, y: 14),
+            rotation: .pi / 12,
+            scaleX: 1.3,
+            scaleY: 1.3,
+            cropSize: CGSize(width: 220, height: 300),
+            imageViewSize: CGSize(width: 480, height: 640),
+            cropRegion: CropRegion(topLeft: CGPoint(x: 30, y: 25),
+                                   topRight: CGPoint(x: 250, y: 40),
+                                   bottomLeft: CGPoint(x: 20, y: 320),
+                                   bottomRight: CGPoint(x: 245, y: 335)),
+            horizontalSkewDegrees: 12,
+            verticalSkewDegrees: -7
+        )
+        info.viewReconstruction = CropInfo.ViewReconstruction(
+            skewSublayerTransform: skew,
+            scrollContentOffset: CGPoint(x: 60, y: 120),
+            scrollBoundsSize: CGSize(width: 220, height: 300),
+            imageContainerFrame: CGRect(x: -10, y: -15, width: 624, height: 832),
+            scrollViewTransform: CGAffineTransform(rotationAngle: .pi / 12).scaledBy(x: -1, y: 1)
+        )
+        return info
+    }
+
+    /// A crop over a large image: geometry identical in shape to a normal crop,
+    /// exercised through the CIImage path in the behavioral test below.
+    private func makeLargeImageCropInfo(imageSize: CGSize,
+                                        viewSize: CGSize,
+                                        cropSize: CGSize,
+                                        zoom: CGFloat,
+                                        contentOffset: CGPoint) -> CropInfo {
+        let containerCenter = CGPoint(x: viewSize.width * zoom / 2, y: viewSize.height * zoom / 2)
+        let cropBoxCenter = CGPoint(x: contentOffset.x + cropSize.width / 2,
+                                    y: contentOffset.y + cropSize.height / 2)
+        var info = CropInfo(
+            translation: CGPoint(x: containerCenter.x - cropBoxCenter.x,
+                                 y: containerCenter.y - cropBoxCenter.y),
+            rotation: 0,
+            scaleX: zoom,
+            scaleY: zoom,
+            cropSize: cropSize,
+            imageViewSize: viewSize,
+            cropRegion: CropRegion(topLeft: .zero, topRight: .zero,
+                                   bottomLeft: .zero, bottomRight: .zero)
+        )
+        info.viewReconstruction = CropInfo.ViewReconstruction(
+            skewSublayerTransform: CATransform3DIdentity,
+            scrollContentOffset: contentOffset,
+            scrollBoundsSize: cropSize,
+            imageContainerFrame: CGRect(origin: .zero,
+                                        size: CGSize(width: viewSize.width * zoom,
+                                                     height: viewSize.height * zoom)),
+            scrollViewTransform: .identity
+        )
+        return info
+    }
+
+    // MARK: - Equality helpers
+
+    private func assertEqual(_ lhs: CropInfo, _ rhs: CropInfo,
+                             file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(lhs.translation, rhs.translation, "translation", file: file, line: line)
+        XCTAssertEqual(lhs.rotation, rhs.rotation, "rotation", file: file, line: line)
+        XCTAssertEqual(lhs.scaleX, rhs.scaleX, "scaleX", file: file, line: line)
+        XCTAssertEqual(lhs.scaleY, rhs.scaleY, "scaleY", file: file, line: line)
+        XCTAssertEqual(lhs.cropSize, rhs.cropSize, "cropSize", file: file, line: line)
+        XCTAssertEqual(lhs.imageViewSize, rhs.imageViewSize, "imageViewSize", file: file, line: line)
+        XCTAssertEqual(lhs.cropRegion, rhs.cropRegion, "cropRegion", file: file, line: line)
+        XCTAssertEqual(lhs.horizontalSkewDegrees, rhs.horizontalSkewDegrees,
+                       "horizontalSkewDegrees", file: file, line: line)
+        XCTAssertEqual(lhs.verticalSkewDegrees, rhs.verticalSkewDegrees,
+                       "verticalSkewDegrees", file: file, line: line)
+
+        switch (lhs.viewReconstruction, rhs.viewReconstruction) {
+        case (nil, nil):
+            break
+        case let (lvr?, rvr?):
+            XCTAssertTrue(CATransform3DEqualToTransform(lvr.skewSublayerTransform,
+                                                        rvr.skewSublayerTransform),
+                          "skewSublayerTransform", file: file, line: line)
+            XCTAssertEqual(lvr.scrollContentOffset, rvr.scrollContentOffset,
+                           "scrollContentOffset", file: file, line: line)
+            XCTAssertEqual(lvr.scrollBoundsSize, rvr.scrollBoundsSize,
+                           "scrollBoundsSize", file: file, line: line)
+            XCTAssertEqual(lvr.imageContainerFrame, rvr.imageContainerFrame,
+                           "imageContainerFrame", file: file, line: line)
+            XCTAssertEqual(lvr.scrollViewTransform, rvr.scrollViewTransform,
+                           "scrollViewTransform", file: file, line: line)
+        default:
+            XCTFail("viewReconstruction presence differs", file: file, line: line)
+        }
+    }
+
+    private func roundTripped(_ info: CropInfo,
+                              file: StaticString = #filePath, line: UInt = #line) throws -> CropInfo {
+        let data = try JSONEncoder().encode(info)
+        return try JSONDecoder().decode(CropInfo.self, from: data)
+    }
+
+    // MARK: - Round-trip equality
+
+    func testStandardCropInfoRoundTrips() throws {
+        let info = makeStandardCropInfo()
+        assertEqual(info, try roundTripped(info))
+    }
+
+    func testFixedRatioCropInfoRoundTrips() throws {
+        let info = makeFixedRatioCropInfo()
+        assertEqual(info, try roundTripped(info))
+    }
+
+    func testRotatedCropInfoRoundTrips() throws {
+        let info = makeRotatedCropInfo()
+        assertEqual(info, try roundTripped(info))
+    }
+
+    func testPerspectiveCropInfoRoundTrips() throws {
+        let info = makePerspectiveCropInfo()
+        assertEqual(info, try roundTripped(info))
+    }
+
+    /// A nil viewReconstruction (a CropInfo a caller builds directly) must
+    /// survive the round-trip as nil, not become a zeroed struct.
+    func testNilViewReconstructionRoundTripsAsNil() throws {
+        let info = makeStandardCropInfo()
+        XCTAssertNil(info.viewReconstruction)
+        XCTAssertNil(try roundTripped(info).viewReconstruction)
+    }
+
+    // MARK: - Behavioral equivalence (decoded behaves like same-session)
+
+    /// Draws a 4-quadrant colored pattern so any coordinate-space mistake
+    /// changes sampled colors.
+    private func makePatternImage(width: Int, height: Int) -> UIImage {
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(data: nil, width: width, height: height,
+                                bitsPerComponent: 8, bytesPerRow: 0,
+                                space: colorSpace,
+                                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue)!
+        let halfW = CGFloat(width) / 2
+        let halfH = CGFloat(height) / 2
+        context.setFillColor(UIColor.red.cgColor)
+        context.fill(CGRect(x: 0, y: 0, width: halfW, height: halfH))
+        context.setFillColor(UIColor.green.cgColor)
+        context.fill(CGRect(x: halfW, y: 0, width: halfW, height: halfH))
+        context.setFillColor(UIColor.blue.cgColor)
+        context.fill(CGRect(x: 0, y: halfH, width: halfW, height: halfH))
+        context.setFillColor(UIColor.yellow.cgColor)
+        context.fill(CGRect(x: halfW, y: halfH, width: halfW, height: halfH))
+        return UIImage(cgImage: context.makeImage()!, scale: 1, orientation: .up)
+    }
+
+    private func pixel(of image: UIImage, atNormalized point: CGPoint) -> [CGFloat]? {
+        guard let cgImage = image.cgImage else { return nil }
+        let posX = Int(CGFloat(cgImage.width) * point.x)
+        let posY = Int(CGFloat(cgImage.height) * point.y)
+        var data = [UInt8](repeating: 0, count: 4)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        guard let context = CGContext(data: &data, width: 1, height: 1,
+                                      bitsPerComponent: 8, bytesPerRow: 4,
+                                      space: colorSpace,
+                                      bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) else { return nil }
+        context.draw(cgImage, in: CGRect(x: -CGFloat(posX),
+                                         y: CGFloat(posY) - CGFloat(cgImage.height) + 1,
+                                         width: CGFloat(cgImage.width),
+                                         height: CGFloat(cgImage.height)))
+        return data.map { CGFloat($0) / 255.0 }
+    }
+
+    private func assertSameOutput(_ lhs: UIImage?, _ rhs: UIImage?,
+                                  file: StaticString = #filePath, line: UInt = #line) {
+        guard let lhs = lhs, let rhs = rhs else {
+            XCTFail("crop returned nil", file: file, line: line); return
+        }
+        XCTAssertEqual(lhs.size.width, rhs.size.width, accuracy: 2.0, "width", file: file, line: line)
+        XCTAssertEqual(lhs.size.height, rhs.size.height, accuracy: 2.0, "height", file: file, line: line)
+        let samplePoints = [CGPoint(x: 0.25, y: 0.25), CGPoint(x: 0.75, y: 0.25),
+                            CGPoint(x: 0.25, y: 0.75), CGPoint(x: 0.75, y: 0.75),
+                            CGPoint(x: 0.5, y: 0.5)]
+        for point in samplePoints {
+            guard let lhsPixel = pixel(of: lhs, atNormalized: point),
+                  let rhsPixel = pixel(of: rhs, atNormalized: point) else {
+                XCTFail("could not sample \(point)", file: file, line: line); continue
+            }
+            for channel in 0..<3 {
+                XCTAssertEqual(lhsPixel[channel], rhsPixel[channel], accuracy: 0.1,
+                               "pixel mismatch at \(point) channel \(channel)", file: file, line: line)
+            }
+        }
+    }
+
+    /// The legacy crop path produces the same image from a decoded CropInfo as
+    /// from the original — the round-trip does not alter crop behavior.
+    func testDecodedCropInfoProducesSameLegacyCrop() throws {
+        let image = makePatternImage(width: 1000, height: 800)
+        let info = makeLargeImageCropInfo(imageSize: image.size,
+                                          viewSize: CGSize(width: 500, height: 400),
+                                          cropSize: CGSize(width: 200, height: 160),
+                                          zoom: 1,
+                                          contentOffset: CGPoint(x: 150, y: 120))
+        assertSameOutput(image.crop(by: info), image.crop(by: try roundTripped(info)))
+    }
+
+    /// The large-image (CIImage) crop path — which relies on the reconstructed
+    /// view state — also produces the same image after a round-trip.
+    func testDecodedCropInfoProducesSameCICrop() throws {
+        let image = makePatternImage(width: 1000, height: 800)
+        let info = makeLargeImageCropInfo(imageSize: image.size,
+                                          viewSize: CGSize(width: 500, height: 400),
+                                          cropSize: CGSize(width: 200, height: 160),
+                                          zoom: 2,
+                                          contentOffset: CGPoint(x: 400, y: 320))
+        assertSameOutput(image.cropWithCIImage(by: info),
+                         image.cropWithCIImage(by: try roundTripped(info)))
+    }
+}


### PR DESCRIPTION
## Summary

Implements #536. `CropInfo` could not be reliably persisted and restored across app sessions: it was not `Codable`, and the internal view-reconstruction state needed by the perspective-skew and large-image (CIImage) crop paths could not be rebuilt by hand — so offline restore of those crops was impossible.

This makes `CropInfo` (and `CropRegion`) `Codable`. A decoded `CropInfo` carries the opaque reconstruction state and crops **identically** to a same-session instance.

## Changes

- **`CropInfo` and `CropRegion`** now conform to `Codable` (synthesized).
- **`CropInfo.ViewReconstruction`** gets a manual `Codable` conformance. `CATransform3D` and `CGAffineTransform` aren't `Codable`, so their coefficients are boxed into private `Codable` structs **instead of** adding retroactive conformances to those CoreGraphics/QuartzCore types — a library-level retroactive conformance there would cause a duplicate-conformance link error if the host app (or another dependency) declared the same one.
- **Tests** (`CropInfoCodableTests`): round-trip field equality for standard, fixed-ratio, rotated, perspective-skewed and large-image crops (plus the `nil`-reconstruction edge case), and behavioral-equivalence tests that crop a pattern image with the original vs. a decoded `CropInfo` through both the legacy `crop(by:)` and large-image `cropWithCIImage(by:)` paths.
- **Docs**: new "Persisting and restoring crops (`Codable`)" section in the README `Usage`, and a CHANGELOG entry.

## Usage

```swift
// Save the CropInfo delivered by the delegate (or CropResult.cropInfo in SwiftUI).
let data = try JSONEncoder().encode(cropInfo)

// Later — even in a new session — re-crop offline, no UI:
let restored = try JSONDecoder().decode(CropInfo.self, from: data)
let recropped = Mantis.crop(image: originalImage, by: restored)
```

## Compatibility

Purely additive and source-compatible — existing code needs no changes. The one caveat: if a user previously added their own `extension CropInfo: Codable` workaround, they should remove it after upgrading to avoid a duplicate-conformance error (called out in the CHANGELOG/README).

## Testing

`CropInfoCodableTests` — 7 tests pass; full `MantisTests` suite green (164 tests, 0 failures) on iOS 27 simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `CropInfo` and `CropRegion` can now be saved and restored, making crop settings persist across app sessions.
  * Added support for reopening previously created crops, including more advanced crop configurations.
* **Bug Fixes**
  * Improved reliability when restoring crop state so crop geometry and transform details are preserved after round-tripping.
* **Tests**
  * Added coverage for encoding/decoding crop data and verifying restored crops match the originals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->