### PR TITLE
test: add unit tests for core crop/rotation logic

### DIFF
--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000F2 /* SkewPositioningTests.swift */; };
 		AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000C2 /* GeometryHelperTests.swift */; };
 		AA00000000000000000000D1 /* UIImageExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000000000000000000D2 /* UIImageExtensionsTests.swift */; };
+		AA000000000000000000AE01 /* AngleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000AE02 /* AngleTests.swift */; };
+		AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000BC02 /* RotationCalculatorTests.swift */; };
+		AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */; };
+		AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */; };
 		F2058F252A4004E3008DEBAA /* SlideDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */; };
 		F2058F272A400508008DEBAA /* SlideDialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F262A400508008DEBAA /* SlideDialViewModel.swift */; };
 		F2058F292A417D97008DEBAA /* SlideDialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F282A417D97008DEBAA /* SlideDialTests.swift */; };
@@ -241,6 +245,10 @@
 		AA00000000000000000000F2 /* SkewPositioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkewPositioningTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000C2 /* GeometryHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeometryHelperTests.swift; sourceTree = "<group>"; };
 		AA00000000000000000000D2 /* UIImageExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensionsTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000AE02 /* AngleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000BC02 /* RotationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationCalculatorTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxFreeAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxLockedAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
 		E86127BD26206D01008365BC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MantisLocalizable.strings; sourceTree = "<group>"; };
 		F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialConfig.swift; sourceTree = "<group>"; };
 		F2058F262A400508008DEBAA /* SlideDialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialViewModel.swift; sourceTree = "<group>"; };
@@ -570,6 +578,10 @@
 				AA00000000000000000000F2 /* SkewPositioningTests.swift */,
 				AA00000000000000000000C2 /* GeometryHelperTests.swift */,
 				AA00000000000000000000D2 /* UIImageExtensionsTests.swift */,
+				AA000000000000000000AE02 /* AngleTests.swift */,
+				AA000000000000000000BC02 /* RotationCalculatorTests.swift */,
+				AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */,
+				AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */,
 			);
 			name = MantisTests;
 			path = Tests/MantisTests;
@@ -818,6 +830,10 @@
 				AA00000000000000000000F1 /* SkewPositioningTests.swift in Sources */,
 				AA00000000000000000000C1 /* GeometryHelperTests.swift in Sources */,
 				AA00000000000000000000D1 /* UIImageExtensionsTests.swift in Sources */,
+				AA000000000000000000AE01 /* AngleTests.swift in Sources */,
+				AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */,
+				AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */,
+				AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */,
 				F24DCFE629A9E53E00D8E8C1 /* UIViewExtensions.swift in Sources */,
 				OBJ_119 /* MantisTests.swift in Sources */,
 				660D4F5D298E33F800C4E11A /* ImageContainerTests.swift in Sources */,

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -79,6 +79,8 @@
 		AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000BC02 /* RotationCalculatorTests.swift */; };
 		AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */; };
 		AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */; };
+		AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */; };
+		AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000FR02 /* FixedRatioManagerTests.swift */; };
 		F2058F252A4004E3008DEBAA /* SlideDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */; };
 		F2058F272A400508008DEBAA /* SlideDialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F262A400508008DEBAA /* SlideDialViewModel.swift */; };
 		F2058F292A417D97008DEBAA /* SlideDialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F282A417D97008DEBAA /* SlideDialTests.swift */; };
@@ -249,6 +251,8 @@
 		AA000000000000000000BC02 /* RotationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationCalculatorTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxFreeAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxLockedAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphicsExtensionsTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000FR02 /* FixedRatioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRatioManagerTests.swift; sourceTree = "<group>"; };
 		E86127BD26206D01008365BC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MantisLocalizable.strings; sourceTree = "<group>"; };
 		F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialConfig.swift; sourceTree = "<group>"; };
 		F2058F262A400508008DEBAA /* SlideDialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialViewModel.swift; sourceTree = "<group>"; };
@@ -582,6 +586,8 @@
 				AA000000000000000000BC02 /* RotationCalculatorTests.swift */,
 				AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */,
 				AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */,
+				AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */,
+				AA000000000000000000FR02 /* FixedRatioManagerTests.swift */,
 			);
 			name = MantisTests;
 			path = Tests/MantisTests;
@@ -834,6 +840,8 @@
 				AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */,
 				AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */,
 				AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */,
+				AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */,
+				AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */,
 				F24DCFE629A9E53E00D8E8C1 /* UIViewExtensions.swift in Sources */,
 				OBJ_119 /* MantisTests.swift in Sources */,
 				660D4F5D298E33F800C4E11A /* ImageContainerTests.swift in Sources */,

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */; };
 		AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */; };
 		AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000FR02 /* FixedRatioManagerTests.swift */; };
+		AA000000000000000000CA01 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */; };
+		AA000000000000000000SR01 /* SlideRulerPositionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */; };
 		F2058F252A4004E3008DEBAA /* SlideDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */; };
 		F2058F272A400508008DEBAA /* SlideDialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F262A400508008DEBAA /* SlideDialViewModel.swift */; };
 		F2058F292A417D97008DEBAA /* SlideDialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F282A417D97008DEBAA /* SlideDialTests.swift */; };
@@ -253,6 +255,8 @@
 		AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxLockedAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphicsExtensionsTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000FR02 /* FixedRatioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRatioManagerTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideRulerPositionHelperTests.swift; sourceTree = "<group>"; };
 		E86127BD26206D01008365BC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MantisLocalizable.strings; sourceTree = "<group>"; };
 		F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialConfig.swift; sourceTree = "<group>"; };
 		F2058F262A400508008DEBAA /* SlideDialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialViewModel.swift; sourceTree = "<group>"; };
@@ -588,6 +592,8 @@
 				AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */,
 				AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */,
 				AA000000000000000000FR02 /* FixedRatioManagerTests.swift */,
+				AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */,
+				AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */,
 			);
 			name = MantisTests;
 			path = Tests/MantisTests;
@@ -842,6 +848,8 @@
 				AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */,
 				AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */,
 				AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */,
+				AA000000000000000000CA01 /* CGAffineTransformExtensionsTests.swift in Sources */,
+				AA000000000000000000SR01 /* SlideRulerPositionHelperTests.swift in Sources */,
 				F24DCFE629A9E53E00D8E8C1 /* UIViewExtensions.swift in Sources */,
 				OBJ_119 /* MantisTests.swift in Sources */,
 				660D4F5D298E33F800C4E11A /* ImageContainerTests.swift in Sources */,

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,12 @@ let package = Package(
             exclude: ["Info.plist", "Resources/Info.plist"],
             resources: [.process("Resources"), .copy("PrivacyInfo.xcprivacy")],
             swiftSettings: [.define("MANTIS_SPM")]
+        ),
+        .testTarget(
+            name: "MantisTests",
+            dependencies: ["Mantis"],
+            path: "Tests/MantisTests",
+            swiftSettings: [.define("MANTIS_SPM")]
         )
     ]
 )

--- a/Tests/MantisTests/AngleTests.swift
+++ b/Tests/MantisTests/AngleTests.swift
@@ -1,0 +1,121 @@
+//
+//  AngleTests.swift
+//  MantisTests
+//
+//  Covers the Angle value type: radians<->degrees conversion and the arithmetic
+//  operator overloads used throughout rotation math. These are tiny pure
+//  functions, but they underpin every dial/rotation calculation, so a wrong
+//  conversion factor or a mis-wired operator silently skews every angle.
+//
+
+import XCTest
+@testable import Mantis
+
+final class AngleTests: XCTestCase {
+
+    private let accuracy: CGFloat = 1e-12
+
+    // MARK: - Initialization & conversion
+
+    func testInitWithRadiansExposesRadians() {
+        XCTAssertEqual(Angle(radians: .pi).radians, .pi, accuracy: accuracy)
+    }
+
+    func testRadiansConvertToDegrees() {
+        XCTAssertEqual(Angle(radians: .pi).degrees, 180, accuracy: accuracy)
+        XCTAssertEqual(Angle(radians: .pi / 2).degrees, 90, accuracy: accuracy)
+        XCTAssertEqual(Angle(radians: 0).degrees, 0, accuracy: accuracy)
+    }
+
+    func testInitWithDegreesConvertsToRadians() {
+        XCTAssertEqual(Angle(degrees: 180).radians, .pi, accuracy: accuracy)
+        XCTAssertEqual(Angle(degrees: 90).radians, .pi / 2, accuracy: accuracy)
+        XCTAssertEqual(Angle(degrees: -45).radians, -.pi / 4, accuracy: accuracy)
+    }
+
+    func testDegreesSetterUpdatesRadians() {
+        let angle = Angle(radians: 0)
+        angle.degrees = 90
+        XCTAssertEqual(angle.radians, .pi / 2, accuracy: accuracy)
+    }
+
+    func testRoundTripDegreesRadians() {
+        // Converting degrees -> radians -> degrees must be an identity.
+        XCTAssertEqual(Angle(degrees: 137).degrees, 137, accuracy: 1e-9)
+    }
+
+    // MARK: - description
+
+    func testDescriptionFormatsDegreesWithTwoDecimals() {
+        XCTAssertEqual(Angle(degrees: 45).description, "45.00°")
+        XCTAssertEqual(Angle(degrees: -12.5).description, "-12.50°")
+    }
+
+    // MARK: - Arithmetic operators
+
+    func testAddition() {
+        let sum = Angle(degrees: 30) + Angle(degrees: 60)
+        XCTAssertEqual(sum.degrees, 90, accuracy: 1e-9)
+    }
+
+    func testAdditionAssignment() {
+        var angle = Angle(degrees: 30)
+        angle += Angle(degrees: 15)
+        XCTAssertEqual(angle.degrees, 45, accuracy: 1e-9)
+    }
+
+    func testSubtraction() {
+        let diff = Angle(degrees: 90) - Angle(degrees: 30)
+        XCTAssertEqual(diff.degrees, 60, accuracy: 1e-9)
+    }
+
+    func testSubtractionAssignment() {
+        var angle = Angle(degrees: 90)
+        angle -= Angle(degrees: 30)
+        XCTAssertEqual(angle.degrees, 60, accuracy: 1e-9)
+    }
+
+    func testMultiplicationMultipliesRadians() {
+        // `*` multiplies the underlying radians, not the degrees.
+        let product = Angle(radians: 2) * Angle(radians: 3)
+        XCTAssertEqual(product.radians, 6, accuracy: accuracy)
+    }
+
+    func testUnaryMinusNegatesRadians() {
+        let negated = -Angle(degrees: 45)
+        XCTAssertEqual(negated.degrees, -45, accuracy: 1e-9)
+    }
+
+    func testDivisionDividesRadians() {
+        let quotient = Angle(radians: 6) / Angle(radians: 2)
+        XCTAssertEqual(quotient.radians, 3, accuracy: accuracy)
+    }
+
+    // MARK: - Division by zero guards
+
+    func testDivisionByZeroWithPositiveNumeratorIsPositiveInfinity() {
+        let result = Angle(radians: 5) / Angle(radians: 0)
+        XCTAssertEqual(result.radians, .infinity)
+    }
+
+    func testDivisionByZeroWithNegativeNumeratorIsNegativeInfinity() {
+        let result = Angle(radians: -5) / Angle(radians: 0)
+        XCTAssertEqual(result.radians, -.infinity)
+    }
+
+    func testZeroDividedByZeroIsZero() {
+        let result = Angle(radians: 0) / Angle(radians: 0)
+        XCTAssertEqual(result.radians, 0, accuracy: accuracy)
+    }
+
+    // MARK: - Comparable
+
+    func testLessThanComparesByRadians() {
+        XCTAssertTrue(Angle(degrees: 30) < Angle(degrees: 60))
+        XCTAssertFalse(Angle(degrees: 60) < Angle(degrees: 30))
+    }
+
+    func testGreaterThanDerivedFromComparable() {
+        XCTAssertTrue(Angle(degrees: 90) > Angle(degrees: 45))
+    }
+}

--- a/Tests/MantisTests/CGAffineTransformExtensionsTests.swift
+++ b/Tests/MantisTests/CGAffineTransformExtensionsTests.swift
@@ -1,0 +1,79 @@
+//
+//  CGAffineTransformExtensionsTests.swift
+//  MantisTests
+//
+//  Covers CGAffineTransform.transformed(by:), which composes a CropInfo's
+//  translation, rotation, and scale onto the receiver in that fixed order.
+//  The order and the fact that it builds *onto* the existing transform (not a
+//  fresh identity) are exactly what the crop/export pipeline relies on, so
+//  these tests pin both.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CGAffineTransformExtensionsTests: XCTestCase {
+
+    private let accuracy: CGFloat = 1e-12
+
+    private func cropInfo(translation: CGPoint = .zero,
+                          rotation: CGFloat = 0,
+                          scaleX: CGFloat = 1,
+                          scaleY: CGFloat = 1) -> CropInfo {
+        CropInfo(translation: translation,
+                 rotation: rotation,
+                 scaleX: scaleX,
+                 scaleY: scaleY,
+                 cropSize: CGSize(width: 100, height: 100),
+                 imageViewSize: CGSize(width: 200, height: 200),
+                 cropRegion: CropRegion(topLeft: .zero,
+                                        topRight: CGPoint(x: 100, y: 0),
+                                        bottomLeft: CGPoint(x: 0, y: 100),
+                                        bottomRight: CGPoint(x: 100, y: 100)))
+    }
+
+    func testTranslationOnlyFromIdentity() {
+        var transform = CGAffineTransform.identity
+        transform.transformed(by: cropInfo(translation: CGPoint(x: 10, y: 20)))
+        XCTAssertEqual(transform, CGAffineTransform(translationX: 10, y: 20))
+    }
+
+    func testScaleOnlyFromIdentity() {
+        var transform = CGAffineTransform.identity
+        transform.transformed(by: cropInfo(scaleX: 2, scaleY: 3))
+        XCTAssertEqual(transform, CGAffineTransform(scaleX: 2, y: 3))
+    }
+
+    func testTranslateThenScaleComposesInOrder() {
+        var transform = CGAffineTransform.identity
+        transform.transformed(by: cropInfo(translation: CGPoint(x: 10, y: 20), scaleX: 2, scaleY: 3))
+        // identity.translatedBy(10,20).scaledBy(2,3) => [a2 b0 c0 d3 tx10 ty20]
+        let expected = CGAffineTransform(a: 2, b: 0, c: 0, d: 3, tx: 10, ty: 20)
+        XCTAssertEqual(transform.a, expected.a, accuracy: accuracy)
+        XCTAssertEqual(transform.d, expected.d, accuracy: accuracy)
+        XCTAssertEqual(transform.tx, expected.tx, accuracy: accuracy)
+        XCTAssertEqual(transform.ty, expected.ty, accuracy: accuracy)
+        // The composed transform maps (1,1) to (2*1+10, 3*1+20) = (12, 23).
+        let mapped = CGPoint(x: 1, y: 1).applying(transform)
+        XCTAssertEqual(mapped.x, 12, accuracy: accuracy)
+        XCTAssertEqual(mapped.y, 23, accuracy: accuracy)
+    }
+
+    func testRotationOnlyRotatesBasisVector() {
+        var transform = CGAffineTransform.identity
+        transform.transformed(by: cropInfo(rotation: .pi / 2))
+        // A quarter turn maps the x-axis unit vector (1,0) to (0,1).
+        let mapped = CGPoint(x: 1, y: 0).applying(transform)
+        XCTAssertEqual(mapped.x, 0, accuracy: 1e-15)
+        XCTAssertEqual(mapped.y, 1, accuracy: 1e-15)
+    }
+
+    func testComposesOntoExistingTransformNotIdentity() {
+        // Starting from a pre-scaled transform, a pure translation must fold
+        // into that scale rather than replace it.
+        var transform = CGAffineTransform(scaleX: 2, y: 2)
+        transform.transformed(by: cropInfo(translation: CGPoint(x: 5, y: 0)))
+        // [2 0 0 2 0 0].translatedBy(5,0) => tx = 2*5 = 10, scale preserved.
+        XCTAssertEqual(transform, CGAffineTransform(a: 2, b: 0, c: 0, d: 2, tx: 10, ty: 0))
+    }
+}

--- a/Tests/MantisTests/CoreGraphicsExtensionsTests.swift
+++ b/Tests/MantisTests/CoreGraphicsExtensionsTests.swift
@@ -1,0 +1,156 @@
+//
+//  CoreGraphicsExtensionsTests.swift
+//  MantisTests
+//
+//  Covers the CGVector / CGRect / CGPoint helper math used by the rotation and
+//  skew geometry: magnitude, normalization, dot/cross products, rotation, and
+//  the signed/unsigned angle-between helpers. Also covers the NaN/infinity
+//  detection getters (isBad / hasNaN).
+//
+//  Note: the `.checked` accessors trip an assertionFailure on bad input, so
+//  these tests only feed them valid values; the bad-input paths are exercised
+//  only through the non-asserting `isBad` / `hasNaN` getters.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CoreGraphicsExtensionsTests: XCTestCase {
+
+    private let accuracy: CGFloat = 1e-12
+
+    // MARK: - isBad / hasNaN detection
+
+    func testFloatingPointIsBad() {
+        XCTAssertTrue(CGFloat.nan.isBad)
+        XCTAssertTrue(CGFloat.infinity.isBad)
+        XCTAssertTrue((-CGFloat.infinity).isBad)
+        XCTAssertFalse(CGFloat(1.5).isBad)
+        XCTAssertFalse(CGFloat(0).isBad)
+    }
+
+    func testCGSizeHasNaN() {
+        XCTAssertTrue(CGSize(width: CGFloat.nan, height: 1).hasNaN)
+        XCTAssertTrue(CGSize(width: 1, height: CGFloat.infinity).hasNaN)
+        XCTAssertFalse(CGSize(width: 10, height: 20).hasNaN)
+    }
+
+    func testCGPointHasNaN() {
+        XCTAssertTrue(CGPoint(x: CGFloat.nan, y: 0).hasNaN)
+        XCTAssertFalse(CGPoint(x: 3, y: 4).hasNaN)
+    }
+
+    func testCGRectHasNaN() {
+        XCTAssertTrue(CGRect(x: CGFloat.nan, y: 0, width: 1, height: 1).hasNaN)
+        XCTAssertTrue(CGRect(x: 0, y: 0, width: CGFloat.infinity, height: 1).hasNaN)
+        XCTAssertFalse(CGRect(x: 0, y: 0, width: 100, height: 50).hasNaN)
+    }
+
+    func testCGVectorHasNaN() {
+        XCTAssertTrue(CGVector(dx: CGFloat.nan, dy: 0).hasNaN)
+        XCTAssertFalse(CGVector(dx: 1, dy: 2).hasNaN)
+    }
+
+    // MARK: - CGRect.center
+
+    func testRectCenter() {
+        let rect = CGRect(x: 10, y: 20, width: 100, height: 50)
+        XCTAssertEqual(rect.center, CGPoint(x: 60, y: 45))
+    }
+
+    // MARK: - CGPoint.vector
+
+    func testPointToVector() {
+        XCTAssertEqual(CGPoint(x: 3, y: 4).vector, CGVector(dx: 3, dy: 4))
+    }
+
+    // MARK: - CGVector basics
+
+    func testRootVector() {
+        XCTAssertEqual(CGVector.root, CGVector(dx: 1, dy: 0))
+    }
+
+    func testMagnitude() {
+        XCTAssertEqual(CGVector(dx: 3, dy: 4).magnitude, 5, accuracy: accuracy)
+    }
+
+    func testNormalized() {
+        let unit = CGVector(dx: 3, dy: 4).normalized
+        XCTAssertEqual(unit.dx, 0.6, accuracy: accuracy)
+        XCTAssertEqual(unit.dy, 0.8, accuracy: accuracy)
+    }
+
+    func testVectorToPoint() {
+        XCTAssertEqual(CGVector(dx: 5, dy: 6).point, CGPoint(x: 5, y: 6))
+    }
+
+    // MARK: - CGVector arithmetic
+
+    func testDotProduct() {
+        XCTAssertEqual(CGVector(dx: 1, dy: 2).dot(CGVector(dx: 3, dy: 4)), 11, accuracy: accuracy)
+    }
+
+    func testAdd() {
+        XCTAssertEqual(CGVector(dx: 1, dy: 2).add(CGVector(dx: 3, dy: 4)), CGVector(dx: 4, dy: 6))
+    }
+
+    func testCrossProduct() {
+        // (1,0) x (0,1) = 1; the sign encodes orientation.
+        XCTAssertEqual(CGVector(dx: 1, dy: 0).cross(CGVector(dx: 0, dy: 1)), 1, accuracy: accuracy)
+        XCTAssertEqual(CGVector(dx: 0, dy: 1).cross(CGVector(dx: 1, dy: 0)), -1, accuracy: accuracy)
+    }
+
+    func testScale() {
+        XCTAssertEqual(CGVector(dx: 2, dy: 3).scale(2), CGVector(dx: 4, dy: 6))
+    }
+
+    // MARK: - CGVector rotation
+
+    func testRotateQuarterTurn() {
+        let rotated = CGVector(dx: 1, dy: 0).rotate(.pi / 2)
+        XCTAssertEqual(rotated.dx, 0, accuracy: 1e-9)
+        XCTAssertEqual(rotated.dy, 1, accuracy: 1e-9)
+    }
+
+    // MARK: - Initializers
+
+    func testInitFromPointToPoint() {
+        let vec = CGVector(fromPoint: CGPoint(x: 1, y: 1), toPoint: CGPoint(x: 4, y: 5))
+        XCTAssertEqual(vec, CGVector(dx: 3, dy: 4))
+    }
+
+    func testInitFromAngleZero() {
+        let vec = CGVector(angle: 0)
+        XCTAssertEqual(vec.dx, 1, accuracy: 1e-9)
+        XCTAssertEqual(vec.dy, 0, accuracy: 1e-9)
+    }
+
+    func testInitFromNegativeAngleWrapsIntoFullTurn() {
+        // -pi/2 is normalized to 3pi/2 => (0, -1).
+        let vec = CGVector(angle: -.pi / 2)
+        XCTAssertEqual(vec.dx, 0, accuracy: 1e-9)
+        XCTAssertEqual(vec.dy, -1, accuracy: 1e-9)
+    }
+
+    // MARK: - theta helpers
+
+    func testThetaOfVector() {
+        XCTAssertEqual(CGVector(dx: 1, dy: 0).theta, 0, accuracy: accuracy)
+        XCTAssertEqual(CGVector(dx: 0, dy: 1).theta, .pi / 2, accuracy: accuracy)
+    }
+
+    func testUnsignedThetaBetweenVectorsIsAlwaysPositive() {
+        let vecA = CGVector(dx: 1, dy: 0)
+        let vecB = CGVector(dx: 0, dy: 1)
+        XCTAssertEqual(CGVector.theta(vecA, vec2: vecB), .pi / 2, accuracy: 1e-9)
+        // Order does not matter for the unsigned angle.
+        XCTAssertEqual(CGVector.theta(vecB, vec2: vecA), .pi / 2, accuracy: 1e-9)
+    }
+
+    func testSignedThetaEncodesOrientation() {
+        let vecA = CGVector(dx: 1, dy: 0)
+        let vecB = CGVector(dx: 0, dy: 1)
+        XCTAssertEqual(CGVector.signedTheta(vecA, vec2: vecB), -.pi / 2, accuracy: 1e-9)
+        XCTAssertEqual(CGVector.signedTheta(vecB, vec2: vecA), .pi / 2, accuracy: 1e-9)
+    }
+}

--- a/Tests/MantisTests/CropBoxFreeAspectFrameUpdaterTests.swift
+++ b/Tests/MantisTests/CropBoxFreeAspectFrameUpdaterTests.swift
@@ -1,0 +1,95 @@
+//
+//  CropBoxFreeAspectFrameUpdaterTests.swift
+//  MantisTests
+//
+//  Covers the free-aspect crop-box resize math: dragging one edge or corner
+//  by (xDelta, yDelta) grows/shrinks the box while the opposite edge stays
+//  put. Also covers the minimumAspectRatio guard that rejects a resize which
+//  would make the box too thin. Pure struct math, so a sign flip here drags
+//  the wrong edge or lets the box collapse.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CropBoxFreeAspectFrameUpdaterTests: XCTestCase {
+
+    // A non-square, non-origin start frame so origin and size bugs both surface.
+    private let originFrame = CGRect(x: 10, y: 20, width: 100, height: 80)
+    private let contentFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+    private func makeUpdater(edge: CropViewAuxiliaryIndicatorHandleType,
+                             minimumAspectRatio: CGFloat = 0) -> CropBoxFreeAspectFrameUpdater {
+        var updater = CropBoxFreeAspectFrameUpdater(tappedEdge: edge,
+                                                    contentFrame: contentFrame,
+                                                    cropOriginFrame: originFrame,
+                                                    cropBoxFrame: originFrame)
+        updater.minimumAspectRatio = minimumAspectRatio
+        return updater
+    }
+
+    // MARK: - Single edges
+
+    func testRightEdgeGrowsWidthOnly() {
+        var updater = makeUpdater(edge: .right)
+        updater.updateCropBoxFrame(xDelta: 30, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 10, y: 20, width: 130, height: 80))
+    }
+
+    func testLeftEdgeMovesOriginAndShrinksWidth() {
+        var updater = makeUpdater(edge: .left)
+        updater.updateCropBoxFrame(xDelta: 30, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 40, y: 20, width: 70, height: 80))
+    }
+
+    func testTopEdgeMovesOriginAndShrinksHeight() {
+        var updater = makeUpdater(edge: .top)
+        updater.updateCropBoxFrame(xDelta: 0, yDelta: 15)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 10, y: 35, width: 100, height: 65))
+    }
+
+    func testBottomEdgeGrowsHeightOnly() {
+        var updater = makeUpdater(edge: .bottom)
+        updater.updateCropBoxFrame(xDelta: 0, yDelta: 15)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 10, y: 20, width: 100, height: 95))
+    }
+
+    // MARK: - Corners combine two edges
+
+    func testTopLeftCornerUpdatesBothEdges() {
+        var updater = makeUpdater(edge: .topLeft)
+        updater.updateCropBoxFrame(xDelta: 30, yDelta: 15)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 40, y: 35, width: 70, height: 65))
+    }
+
+    func testBottomRightCornerUpdatesBothEdges() {
+        var updater = makeUpdater(edge: .bottomRight)
+        updater.updateCropBoxFrame(xDelta: 30, yDelta: 15)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 10, y: 20, width: 130, height: 95))
+    }
+
+    // MARK: - No-op edge
+
+    func testNoneEdgeLeavesFrameUnchanged() {
+        var updater = makeUpdater(edge: .none)
+        updater.updateCropBoxFrame(xDelta: 30, yDelta: 15)
+        XCTAssertEqual(updater.cropBoxFrame, originFrame)
+    }
+
+    // MARK: - minimumAspectRatio guard
+
+    func testResizeRejectedWhenItWouldViolateMinimumAspectRatio() {
+        // Growing width to 200 against height 80 gives ratio 0.4 (< 0.5), so the
+        // update must be dropped and the frame left untouched.
+        var updater = makeUpdater(edge: .right, minimumAspectRatio: 0.5)
+        updater.updateCropBoxFrame(xDelta: 100, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, originFrame)
+    }
+
+    func testResizeAllowedWhenItStaysAboveMinimumAspectRatio() {
+        // Growing width to 120 against height 80 gives ratio 0.666 (> 0.5): allowed.
+        var updater = makeUpdater(edge: .right, minimumAspectRatio: 0.5)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 10, y: 20, width: 120, height: 80))
+    }
+}

--- a/Tests/MantisTests/CropBoxLockedAspectFrameUpdaterTests.swift
+++ b/Tests/MantisTests/CropBoxLockedAspectFrameUpdaterTests.swift
@@ -1,0 +1,105 @@
+//
+//  CropBoxLockedAspectFrameUpdaterTests.swift
+//  MantisTests
+//
+//  Characterizes the fixed-aspect crop-box resize math: dragging an edge or
+//  corner must keep the box's aspect ratio locked. These are the exact frames
+//  the current implementation produces; they pin the behavior so a refactor
+//  that changes the geometry has to be a deliberate choice, not a silent
+//  regression. Side edges recompute height from width (and vice versa); corners
+//  use a scale factor with ceil() rounding.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CropBoxLockedAspectFrameUpdaterTests: XCTestCase {
+
+    private let contentFrame = CGRect(x: 0, y: 0, width: 1000, height: 1000)
+
+    private func makeUpdater(edge: CropViewAuxiliaryIndicatorHandleType,
+                             originFrame: CGRect) -> CropBoxLockedAspectFrameUpdater {
+        CropBoxLockedAspectFrameUpdater(tappedEdge: edge,
+                                        contentFrame: contentFrame,
+                                        cropOriginFrame: originFrame,
+                                        cropBoxFrame: originFrame)
+    }
+
+    // MARK: - Side edges keep the 1:1 ratio (square start frame)
+
+    private let square = CGRect(x: 0, y: 0, width: 100, height: 100)
+
+    func testRightEdgeGrowsAndKeepsSquare() {
+        var updater = makeUpdater(edge: .right, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 0, width: 120, height: 120))
+    }
+
+    func testLeftEdgeShrinksAndKeepsSquare() {
+        var updater = makeUpdater(edge: .left, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 0)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 20, y: 0, width: 80, height: 80))
+    }
+
+    func testTopEdgeShrinksAndKeepsSquare() {
+        var updater = makeUpdater(edge: .top, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 0, yDelta: 20)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 20, width: 80, height: 80))
+    }
+
+    func testBottomEdgeGrowsAndKeepsSquare() {
+        var updater = makeUpdater(edge: .bottom, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 0, yDelta: 20)
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 0, width: 120, height: 120))
+    }
+
+    // MARK: - Side edge with a non-square ratio (2:1)
+
+    func testRightEdgeKeepsTwoToOneRatio() {
+        let wide = CGRect(x: 0, y: 0, width: 200, height: 100) // aspectRatio 2
+        var updater = makeUpdater(edge: .right, originFrame: wide)
+        updater.updateCropBoxFrame(xDelta: 40, yDelta: 0)
+        // width 200+40=240; height 240/2=120; box grows down from y=0.
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 0, width: 240, height: 120))
+    }
+
+    // MARK: - Corners use a scale factor with ceil() rounding
+
+    func testBottomRightCornerScalesFromTopLeftAnchor() {
+        var updater = makeUpdater(edge: .bottomRight, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 20)
+        // scale = ((1+0.2)+(1+0.2))/2 = 1.2 => 120x120, origin unchanged.
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 0, width: 120, height: 120))
+    }
+
+    func testTopLeftCornerScalesFromBottomRightAnchor() {
+        var updater = makeUpdater(edge: .topLeft, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 20)
+        // scale = ((1-0.2)+(1-0.2))/2 = 0.8 => 80x80; origin shifts by (100-80).
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 20, y: 20, width: 80, height: 80))
+    }
+
+    func testBottomLeftCornerPinsRightEdge() {
+        var updater = makeUpdater(edge: .bottomLeft, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: -20)
+        // rule .bottomLeft = (xDelta, -yDelta) = (20, 20); scale 0.8 => 80x80.
+        // origin.x = maxX(100) - width(80) = 20; origin.y stays 0.
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 20, y: 0, width: 80, height: 80))
+    }
+
+    func testCeilRoundingProducesIntegralSize() {
+        // scale that lands on a fraction must be rounded up by ceil().
+        var updater = makeUpdater(edge: .bottomRight, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 5, yDelta: 0)
+        // distance.x = 1+0.05, distance.y = 1 => scale 1.025 => 102.5 -> ceil 103.
+        XCTAssertEqual(updater.cropBoxFrame, CGRect(x: 0, y: 0, width: 103, height: 103))
+    }
+
+    // MARK: - No-op edge
+
+    func testNoneEdgeLeavesFrameUnchanged() {
+        var updater = makeUpdater(edge: .none, originFrame: square)
+        updater.updateCropBoxFrame(xDelta: 20, yDelta: 20)
+        XCTAssertEqual(updater.cropBoxFrame, square)
+    }
+}

--- a/Tests/MantisTests/FixedRatioManagerTests.swift
+++ b/Tests/MantisTests/FixedRatioManagerTests.swift
@@ -1,0 +1,107 @@
+//
+//  FixedRatioManagerTests.swift
+//  MantisTests
+//
+//  Covers the aspect-ratio list builder: which entries each RatioOptions flag
+//  contributes, RatioItemType's positive-ratio validation, de-duplication by
+//  name, and the tail-sort that orders the ratios while keeping the first two
+//  fixed entries in place.
+//
+
+import XCTest
+@testable import Mantis
+
+final class FixedRatioManagerTests: XCTestCase {
+
+    // MARK: - RatioItemType validation
+
+    func testRatioItemRejectsNonPositiveHorizontalRatio() {
+        XCTAssertNil(RatioItemType(nameH: "x", ratioH: 0, nameV: "x", ratioV: 1))
+        XCTAssertNil(RatioItemType(nameH: "x", ratioH: -1, nameV: "x", ratioV: 1))
+    }
+
+    func testRatioItemRejectsNonPositiveVerticalRatio() {
+        XCTAssertNil(RatioItemType(nameH: "x", ratioH: 1, nameV: "x", ratioV: 0))
+    }
+
+    func testRatioItemAcceptsPositiveRatios() {
+        let item = RatioItemType(nameH: "3:2", ratioH: 1.5, nameV: "2:3", ratioV: 2.0 / 3.0)
+        XCTAssertNotNil(item)
+        XCTAssertEqual(item?.ratioH, 1.5)
+        XCTAssertEqual(item?.nameH, "3:2")
+    }
+
+    // MARK: - RatioOptions contributions
+
+    func testEmptyOptionsProduceNoRatios() {
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0, ratioOptions: [])
+        XCTAssertTrue(manager.ratios.isEmpty)
+    }
+
+    func testSquareOptionAddsSingleUnitRatio() {
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0, ratioOptions: [.square])
+        XCTAssertEqual(manager.ratios.count, 1)
+        XCTAssertEqual(manager.ratios.first?.ratioH, 1.0)
+        XCTAssertEqual(manager.ratios.first?.ratioV, 1.0)
+    }
+
+    func testOriginalOptionUsesOriginalRatioH() {
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.5, ratioOptions: [.original])
+        XCTAssertEqual(manager.ratios.count, 1)
+        XCTAssertEqual(manager.ratios.first?.ratioH, 1.5)
+        XCTAssertEqual(manager.ratios.first?.ratioV, 1.5)
+    }
+
+    func testExtraDefaultRatiosAddSixEntries() {
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0, ratioOptions: [.extraDefaultRatios])
+        XCTAssertEqual(manager.ratios.count, 6)
+        let names = manager.ratios.map { $0.nameH }
+        XCTAssertEqual(Set(names), Set(["3:2", "5:3", "4:3", "5:4", "7:5", "16:9"]))
+    }
+
+    func testAllOptionsWithoutCustomProduceEightEntries() {
+        // original(1) + square(1) + extraDefaultRatios(6) = 8
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0, ratioOptions: .all)
+        XCTAssertEqual(manager.ratios.count, 8)
+    }
+
+    // MARK: - Custom ratios & de-duplication
+
+    func testCustomRatiosAreAppended() {
+        let custom = [RatioItemType(nameH: "21:9", ratioH: 21.0 / 9.0, nameV: "9:21", ratioV: 9.0 / 21.0)!]
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0,
+                                        ratioOptions: [.custom], customRatios: custom)
+        XCTAssertEqual(manager.ratios.count, 1)
+        XCTAssertEqual(manager.ratios.first?.nameH, "21:9")
+    }
+
+    func testDuplicateNamedCustomRatioIsDropped() {
+        // Two entries share nameH "9:9"; the second must be de-duplicated away.
+        let custom = [
+            RatioItemType(nameH: "9:9", ratioH: 1.0, nameV: "9:9", ratioV: 1.0)!,
+            RatioItemType(nameH: "9:9", ratioH: 1.0, nameV: "9:9", ratioV: 1.0)!
+        ]
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0,
+                                        ratioOptions: [.custom], customRatios: custom)
+        XCTAssertEqual(manager.ratios.count, 1)
+    }
+
+    // MARK: - Tail sort keeps the first two entries in place
+
+    func testHorizontalSortOrdersTailByHeightKeepingFirstTwoFixed() {
+        // Five custom ratios; the tail after the first two is out of order by
+        // height. Horizontal sort orders the tail ascending by the height in
+        // "W:H", while the first two entries stay put.
+        let custom = [
+            RatioItemType(nameH: "10:1", ratioH: 10, nameV: "1:10", ratioV: 0.1)!, // fixed head
+            RatioItemType(nameH: "10:2", ratioH: 5, nameV: "2:10", ratioV: 0.2)!,  // fixed head
+            RatioItemType(nameH: "10:9", ratioH: 10.0 / 9, nameV: "9:10", ratioV: 0.9)!,
+            RatioItemType(nameH: "10:3", ratioH: 10.0 / 3, nameV: "3:10", ratioV: 0.3)!,
+            RatioItemType(nameH: "10:7", ratioH: 10.0 / 7, nameV: "7:10", ratioV: 0.7)!
+        ]
+        let manager = FixedRatioManager(type: .horizontal, originalRatioH: 1.0,
+                                        ratioOptions: [.custom], customRatios: custom)
+        XCTAssertEqual(manager.ratios.map { $0.nameH },
+                       ["10:1", "10:2", "10:3", "10:7", "10:9"])
+    }
+}

--- a/Tests/MantisTests/RotationCalculatorTests.swift
+++ b/Tests/MantisTests/RotationCalculatorTests.swift
@@ -1,0 +1,139 @@
+//
+//  RotationCalculatorTests.swift
+//  MantisTests
+//
+//  Covers the polar math behind the rotation dial gesture: mapping a touch
+//  point to an absolute angle around a midpoint, and turning an old/new point
+//  pair into a relative rotation wrapped into (-pi, pi]. An error here shows up
+//  as the dial jumping or spinning the wrong way when a drag crosses the
+//  ±180° seam.
+//
+
+import XCTest
+@testable import Mantis
+
+final class RotationCalculatorTests: XCTestCase {
+
+    private let accuracy: CGFloat = 1e-6
+
+    private func makeCalculator() -> RotationCalculator {
+        // Midpoint at the origin keeps the expected angles easy to reason about.
+        RotationCalculator(midPoint: .zero)
+    }
+
+    // MARK: - Fresh state
+
+    func testFreshCalculatorHasNoRotationAngleOrDistance() {
+        let calculator = makeCalculator()
+        XCTAssertNil(calculator.rotation)
+        XCTAssertNil(calculator.angle)
+        XCTAssertNil(calculator.distance)
+    }
+
+    // MARK: - Absolute angle mapping
+    //
+    // The mapping is: +x axis -> 0, +y axis -> pi/2, -x axis -> pi,
+    // -y axis -> 3pi/2 (angles are normalized into [0, 2pi)).
+
+    func testAngleAlongPositiveXAxisIsZeroModuloTwoPi() {
+        // The +x axis sits exactly on the 0 / 2pi seam. Float rounding in the
+        // atan2 path can land the result infinitesimally below 0, which the
+        // normalization then wraps up to ~2pi. Both are the same angle, so
+        // compare modulo 2pi rather than to a bare 0.
+        let calculator = makeCalculator()
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: 1, y: 0))
+        let angle = calculator.angle ?? .nan
+        let distanceToSeam = min(angle, abs(.pi * 2 - angle))
+        XCTAssertEqual(distanceToSeam, 0, accuracy: accuracy)
+    }
+
+    func testAngleAlongPositiveYAxisIsHalfPi() {
+        let calculator = makeCalculator()
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: 0, y: 1))
+        XCTAssertEqual(calculator.angle ?? .nan, .pi / 2, accuracy: accuracy)
+    }
+
+    func testAngleAlongNegativeXAxisIsPi() {
+        let calculator = makeCalculator()
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: -1, y: 0))
+        XCTAssertEqual(calculator.angle ?? .nan, .pi, accuracy: accuracy)
+    }
+
+    func testAngleAlongNegativeYAxisWrapsToThreeHalfPi() {
+        // Raw angle is -pi/2; the calculator adds 2pi to keep it in [0, 2pi).
+        let calculator = makeCalculator()
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: 0, y: -1))
+        XCTAssertEqual(calculator.angle ?? .nan, .pi * 3 / 2, accuracy: accuracy)
+    }
+
+    // MARK: - Relative rotation
+
+    func testCounterClockwiseQuarterTurn() {
+        // +x (angle 0) -> +y (angle pi/2) is +pi/2.
+        let calculator = makeCalculator()
+        let rotation = calculator.getRotationRadians(byOldPoint: CGPoint(x: 1, y: 0),
+                                                     andNewPoint: CGPoint(x: 0, y: 1))
+        XCTAssertEqual(rotation, .pi / 2, accuracy: accuracy)
+    }
+
+    func testClockwiseQuarterTurn() {
+        // +y (angle pi/2) -> +x (angle 0) is -pi/2.
+        let calculator = makeCalculator()
+        let rotation = calculator.getRotationRadians(byOldPoint: CGPoint(x: 0, y: 1),
+                                                     andNewPoint: CGPoint(x: 1, y: 0))
+        XCTAssertEqual(rotation, -.pi / 2, accuracy: accuracy)
+    }
+
+    func testRotationWrapsWhenCrossingSeamPositive() {
+        // 0 -> 3pi/2 raw is +3pi/2 (> pi), so it wraps to the short way: -pi/2.
+        let calculator = makeCalculator()
+        let rotation = calculator.getRotationRadians(byOldPoint: CGPoint(x: 1, y: 0),
+                                                     andNewPoint: CGPoint(x: 0, y: -1))
+        XCTAssertEqual(rotation, -.pi / 2, accuracy: accuracy)
+    }
+
+    func testRotationWrapsWhenCrossingSeamNegative() {
+        // 3pi/2 -> 0 raw is -3pi/2 (< -pi), so it wraps to the short way: +pi/2.
+        let calculator = makeCalculator()
+        let rotation = calculator.getRotationRadians(byOldPoint: CGPoint(x: 0, y: -1),
+                                                     andNewPoint: CGPoint(x: 1, y: 0))
+        XCTAssertEqual(rotation, .pi / 2, accuracy: accuracy)
+    }
+
+    func testNoMovementYieldsZeroRotation() {
+        let calculator = makeCalculator()
+        let rotation = calculator.getRotationRadians(byOldPoint: CGPoint(x: 1, y: 1),
+                                                     andNewPoint: CGPoint(x: 1, y: 1))
+        XCTAssertEqual(rotation, 0, accuracy: accuracy)
+    }
+
+    // MARK: - Distance
+
+    func testDistanceFromMidpoint() {
+        let calculator = makeCalculator()
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: 3, y: 4))
+        XCTAssertEqual(calculator.distance ?? .nan, 5, accuracy: accuracy)
+    }
+
+    func testDistanceRespectsNonZeroMidpoint() {
+        let calculator = RotationCalculator(midPoint: CGPoint(x: 10, y: 10))
+        _ = calculator.getRotationRadians(byOldPoint: .zero, andNewPoint: CGPoint(x: 13, y: 14))
+        XCTAssertEqual(calculator.distance ?? .nan, 5, accuracy: accuracy)
+    }
+
+    // MARK: - Midpoint offset invariance
+
+    func testRotationIsInvariantToMidpointTranslation() {
+        // Translating both points and the midpoint by the same offset must not
+        // change the measured rotation.
+        let base = makeCalculator()
+        let baseRotation = base.getRotationRadians(byOldPoint: CGPoint(x: 1, y: 0),
+                                                   andNewPoint: CGPoint(x: 0, y: 1))
+
+        let shifted = RotationCalculator(midPoint: CGPoint(x: 100, y: 100))
+        let shiftedRotation = shifted.getRotationRadians(byOldPoint: CGPoint(x: 101, y: 100),
+                                                         andNewPoint: CGPoint(x: 100, y: 101))
+
+        XCTAssertEqual(baseRotation, shiftedRotation, accuracy: accuracy)
+    }
+}

--- a/Tests/MantisTests/SlideRulerPositionHelperTests.swift
+++ b/Tests/MantisTests/SlideRulerPositionHelperTests.swift
@@ -1,0 +1,142 @@
+//
+//  SlideRulerPositionHelperTests.swift
+//  MantisTests
+//
+//  Covers the two SlideRulerPositionHelper strategies that map between the
+//  rotation ruler's scroll offset and a normalized progress ratio. The
+//  bilateral variant is centered (ratio in [-1, 1]); the unilateral variant
+//  starts at one end (ratio in [0, 1]). Both clamp out-of-range offsets, and
+//  getRulerOffsetX / setOffset are inverse-ish mappings the dial depends on.
+//
+
+import XCTest
+@testable import Mantis
+
+final class SlideRulerPositionHelperTests: XCTestCase {
+
+    private let accuracy: CGFloat = 1e-9
+
+    /// A ruler laid out at width 200. Assigning `bounds` after init triggers
+    /// the `bounds` didSet -> setUIFrames(), which lays out the inner
+    /// scrollRulerView (frame = bounds) and sets offsetValue = 0.5 * 200 = 100.
+    /// (The observer does not fire for the frame passed to init, so we set it
+    /// explicitly here to force the layout the helpers read from.)
+    private func makeRuler() -> SlideRuler {
+        let ruler = SlideRuler(frame: CGRect(x: 0, y: 0, width: 200, height: 40),
+                               config: SlideDialConfig())
+        ruler.bounds = CGRect(x: 0, y: 0, width: 200, height: 40)
+        return ruler
+    }
+
+    // MARK: - Bilateral (centered) strategy
+
+    private func makeBilateral() -> (BilateralTypeSlideRulerPositionHelper, SlideRuler) {
+        let helper = BilateralTypeSlideRulerPositionHelper()
+        let ruler = makeRuler()
+        helper.slideRuler = ruler
+        return (helper, ruler)
+    }
+
+    func testBilateralConstants() {
+        let (helper, _) = makeBilateral()
+        XCTAssertEqual(helper.getInitialOffsetRatio(), 0.5, accuracy: accuracy)
+        XCTAssertEqual(helper.getForceAlignCenterX(), 100, accuracy: accuracy) // frame.width / 2
+        XCTAssertEqual(helper.getCentralDotCenterX(), 200, accuracy: accuracy) // frame.width
+    }
+
+    func testBilateralRulerOffsetX() {
+        let (helper, _) = makeBilateral()
+        // progress * offsetValue + offsetValue, offsetValue = 100.
+        XCTAssertEqual(helper.getRulerOffsetX(with: 0), 100, accuracy: accuracy)
+        XCTAssertEqual(helper.getRulerOffsetX(with: 0.5), 150, accuracy: accuracy)
+        XCTAssertEqual(helper.getRulerOffsetX(with: -1), 0, accuracy: accuracy)
+    }
+
+    func testBilateralOffsetRatioIsCenteredAndClamped() {
+        let (helper, ruler) = makeBilateral()
+        // (contentOffset.x - offsetValue) / offsetValue, offsetValue = 100.
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 150, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 0.5, accuracy: accuracy)
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 100, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 0, accuracy: accuracy)
+        // Beyond the ends clamps to +/-1.
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 1000, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 1, accuracy: accuracy)
+        ruler.scrollRulerView.contentOffset = CGPoint(x: -1000, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), -1, accuracy: accuracy)
+    }
+
+    func testBilateralOffsetRatioGuardsZeroOffsetValue() {
+        let (helper, ruler) = makeBilateral()
+        ruler.offsetValue = 0
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 50, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 0, accuracy: accuracy)
+    }
+
+    func testBilateralSetOffset() {
+        let (helper, ruler) = makeBilateral()
+        // offsetX = offsetRatio * (frame.width/2) + frame.width/2, width = 200.
+        helper.setOffset(offsetRatio: 0.5)
+        XCTAssertEqual(ruler.scrollRulerView.contentOffset.x, 150, accuracy: accuracy)
+        helper.setOffset(offsetRatio: -1)
+        XCTAssertEqual(ruler.scrollRulerView.contentOffset.x, 0, accuracy: accuracy)
+    }
+
+    func testBilateralCheckIsCenterPosition() {
+        let (helper, ruler) = makeBilateral()
+        // abs(contentOffset.x - frame.width/2) < limit, center at 100.
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 100, y: 0)
+        XCTAssertTrue(helper.checkIsCenterPosition(with: 1))
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 150, y: 0)
+        XCTAssertFalse(helper.checkIsCenterPosition(with: 10))
+    }
+
+    // MARK: - Unilateral (one-sided) strategy
+
+    private func makeUnilateral() -> (UnilateralTypeSlideRulerPositionHelper, SlideRuler) {
+        let helper = UnilateralTypeSlideRulerPositionHelper()
+        let ruler = makeRuler()
+        helper.slideRuler = ruler
+        return (helper, ruler)
+    }
+
+    func testUnilateralConstants() {
+        let (helper, _) = makeUnilateral()
+        XCTAssertEqual(helper.getInitialOffsetRatio(), 0, accuracy: accuracy)
+        XCTAssertEqual(helper.getForceAlignCenterX(), 0, accuracy: accuracy)
+    }
+
+    func testUnilateralRulerOffsetX() {
+        let (helper, _) = makeUnilateral()
+        // progress * scrollRulerView.frame.width, width = 200.
+        XCTAssertEqual(helper.getRulerOffsetX(with: 0.5), 100, accuracy: accuracy)
+        XCTAssertEqual(helper.getRulerOffsetX(with: 1), 200, accuracy: accuracy)
+    }
+
+    func testUnilateralOffsetRatioIsClampedToUnitRange() {
+        let (helper, ruler) = makeUnilateral()
+        // contentOffset.x / bounds.width, bounds.width = 200.
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 100, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 0.5, accuracy: accuracy)
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 400, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 1, accuracy: accuracy)
+        ruler.scrollRulerView.contentOffset = CGPoint(x: -50, y: 0)
+        XCTAssertEqual(helper.getOffsetRatio(), 0, accuracy: accuracy)
+    }
+
+    func testUnilateralSetOffset() {
+        let (helper, ruler) = makeUnilateral()
+        // offsetRatio * scrollRulerView.frame.width / 2, width = 200.
+        helper.setOffset(offsetRatio: 0.5)
+        XCTAssertEqual(ruler.scrollRulerView.contentOffset.x, 50, accuracy: accuracy)
+    }
+
+    func testUnilateralCheckIsCenterPosition() {
+        let (helper, ruler) = makeUnilateral()
+        // abs(contentOffset.x) < limit.
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 0, y: 0)
+        XCTAssertTrue(helper.checkIsCenterPosition(with: 1))
+        ruler.scrollRulerView.contentOffset = CGPoint(x: 50, y: 0)
+        XCTAssertFalse(helper.checkIsCenterPosition(with: 10))
+    }
+}


### PR DESCRIPTION
## What

Adds direct unit tests for eight pure-logic source files that previously had **zero** dedicated coverage, plus declares the SwiftPM test target that was missing from `Package.swift`.

## Coverage added (99 new test cases)

| Area | Test file | Cases |
|------|-----------|-------|
| Angle math | `AngleTests` | 18 |
| Rotation gesture math | `RotationCalculatorTests` | 13 |
| Free-aspect crop box resize | `CropBoxFreeAspectFrameUpdaterTests` | 9 |
| Locked-aspect crop box resize | `CropBoxLockedAspectFrameUpdaterTests` | 10 |
| CGVector geometry / NaN detection | `CoreGraphicsExtensionsTests` | 22 |
| Aspect-ratio list builder | `FixedRatioManagerTests` | 11 |
| Affine transform composition | `CGAffineTransformExtensionsTests` | 5 |
| Slide-ruler position mapping | `SlideRulerPositionHelperTests` | 11 |

These are all pure input→output logic (angle conversion, crop-box geometry, vector math, ratio de-duplication/sorting, transform composition), where a silent regression would corrupt crop output. The two crop-box updaters and the affine-transform composition are covered with **characterization tests** that pin the current geometry so a future refactor has to change them deliberately.

## Build changes

- `Package.swift`: declares `MantisTests` as an SPM `.testTarget` (previously absent, so pure-SwiftPM tooling couldn't discover the suite). The existing `xcodebuild test -scheme Mantis-Package` flow is unchanged.
- `Mantis.xcodeproj/project.pbxproj`: registers the eight new files in the hand-maintained `MantisTests` target (this project lists test sources explicitly; new files must be added there or they compile to nothing).

## Verification

Full suite green on iOS Simulator (iPhone 16, iOS 18.2): **263 tests, 0 failures** (was 164 before this branch).

## Notes

- `Orientation.swift` was intentionally left untested: it reads `UIApplication.shared.connectedScenes` global state and can't be tested deterministically.
- The `RotationCalculator` +x-axis case is asserted modulo 2π — it sits exactly on the 0/2π float seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive suite of new unit tests covering angles, rotation, vectors, transform composition, crop box resizing, fixed ratios, and slide ruler positioning.
  * Expanded test coverage for edge cases, rounding behavior, clamping, and coordinate calculations.

* **Chores**
  * Updated project and package configuration so the new test files are included in the unit test build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->