### PR TITLE
test: add unit tests for TransformRecord undo/redo bookkeeping

### DIFF
--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000FR02 /* FixedRatioManagerTests.swift */; };
 		AA000000000000000000CA01 /* CGAffineTransformExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */; };
 		AA000000000000000000SR01 /* SlideRulerPositionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */; };
+		AA000000000000000000TR01 /* TransformRecordTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000TR02 /* TransformRecordTests.swift */; };
 		F2058F252A4004E3008DEBAA /* SlideDialConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */; };
 		F2058F272A400508008DEBAA /* SlideDialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F262A400508008DEBAA /* SlideDialViewModel.swift */; };
 		F2058F292A417D97008DEBAA /* SlideDialTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2058F282A417D97008DEBAA /* SlideDialTests.swift */; };
@@ -257,6 +258,7 @@
 		AA000000000000000000FR02 /* FixedRatioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRatioManagerTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGAffineTransformExtensionsTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideRulerPositionHelperTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000TR02 /* TransformRecordTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransformRecordTests.swift; sourceTree = "<group>"; };
 		E86127BD26206D01008365BC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/MantisLocalizable.strings; sourceTree = "<group>"; };
 		F2058F242A4004E3008DEBAA /* SlideDialConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialConfig.swift; sourceTree = "<group>"; };
 		F2058F262A400508008DEBAA /* SlideDialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlideDialViewModel.swift; sourceTree = "<group>"; };
@@ -594,6 +596,7 @@
 				AA000000000000000000FR02 /* FixedRatioManagerTests.swift */,
 				AA000000000000000000CA02 /* CGAffineTransformExtensionsTests.swift */,
 				AA000000000000000000SR02 /* SlideRulerPositionHelperTests.swift */,
+				AA000000000000000000TR02 /* TransformRecordTests.swift */,
 			);
 			name = MantisTests;
 			path = Tests/MantisTests;
@@ -850,6 +853,7 @@
 				AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */,
 				AA000000000000000000CA01 /* CGAffineTransformExtensionsTests.swift in Sources */,
 				AA000000000000000000SR01 /* SlideRulerPositionHelperTests.swift in Sources */,
+				AA000000000000000000TR01 /* TransformRecordTests.swift in Sources */,
 				F24DCFE629A9E53E00D8E8C1 /* UIViewExtensions.swift in Sources */,
 				OBJ_119 /* MantisTests.swift in Sources */,
 				660D4F5D298E33F800C4E11A /* ImageContainerTests.swift in Sources */,

--- a/Tests/MantisTests/TransformRecordTests.swift
+++ b/Tests/MantisTests/TransformRecordTests.swift
@@ -1,0 +1,177 @@
+//
+//  TransformRecordTests.swift
+//  MantisTests
+//
+//  Covers the undo/redo bookkeeping in TransformRecord: which stored crop
+//  state (current vs previous) is pushed to the delegate on redo vs undo, the
+//  applyTransform gate that decides whether the state is applied at all, stack
+//  push/pop, and the reset-button enable logic that depends on the transform
+//  type and the stack depth.
+//
+
+import XCTest
+@testable import Mantis
+
+private final class FakeTransformDelegate: TransformDelegate {
+    let undoManager = UndoManager()
+    var updatedCropStates: [CropState] = []
+    var resetEnableStates: [Bool] = []
+    var undoEnableStates: [Bool] = []
+    var redoEnableStates: [Bool] = []
+
+    func getUndoManager() -> UndoManager { undoManager }
+    func isUndoEnabled() -> Bool { undoManager.canUndo }
+    func isRedoEnabled() -> Bool { undoManager.canRedo }
+    func undo() {}
+    func redo() {}
+    func updateCropState(_ cropState: CropState) { updatedCropStates.append(cropState) }
+    func updateEnableStateForUndo(_ enable: Bool) { undoEnableStates.append(enable) }
+    func updateEnableStateForRedo(_ enable: Bool) { redoEnableStates.append(enable) }
+    func updateEnableStateForReset(_ enable: Bool) { resetEnableStates.append(enable) }
+}
+
+final class TransformRecordTests: XCTestCase {
+
+    private var stack: TransformStack!
+    private var delegate: FakeTransformDelegate!
+
+    override func setUp() {
+        super.setUp()
+        stack = TransformStack()
+        delegate = FakeTransformDelegate()
+        stack.transformDelegate = delegate
+    }
+
+    override func tearDown() {
+        stack = nil
+        delegate = nil
+        super.tearDown()
+    }
+
+    // MARK: - Fixtures
+
+    private func makeTransformation() -> Transformation {
+        Transformation(offset: .zero,
+                       rotation: 0,
+                       scale: 1,
+                       isManuallyZoomed: false,
+                       initialMaskFrame: .zero,
+                       maskFrame: .zero,
+                       cropWorkbenchViewBounds: .zero,
+                       horizontallyFlipped: false,
+                       verticallyFlipped: false)
+    }
+
+    /// A CropState distinguished purely by `degrees`, so tests can tell the
+    /// "previous" and "current" states apart.
+    private func makeCropState(degrees: CGFloat) -> CropState {
+        CropState(rotationType: .none,
+                  degrees: degrees,
+                  aspectRatioLockEnabled: false,
+                  aspectRato: 1,
+                  flipOddTimes: false,
+                  transformation: makeTransformation(),
+                  horizontalSkewDegrees: 0,
+                  verticalSkewDegrees: 0)
+    }
+
+    private func makeRecord(type: TransformType,
+                            previousDegrees: CGFloat,
+                            currentDegrees: CGFloat) -> TransformRecord {
+        TransformRecord(stack: stack,
+                        transformType: type,
+                        actionName: "Test",
+                        previousValues: [.kCurrentTransformState: makeCropState(degrees: previousDegrees)],
+                        currentValues: [.kCurrentTransformState: makeCropState(degrees: currentDegrees)])
+    }
+
+    // MARK: - Redo (addAdjustmentToStack)
+
+    func testAddAppliesCurrentStateWhenApplyTransformTrue() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+
+        XCTAssertEqual(delegate.updatedCropStates.count, 1)
+        XCTAssertEqual(delegate.updatedCropStates.first?.degrees, 20) // the "current" state
+        XCTAssertEqual(stack.top, 1)
+    }
+
+    func testAddDoesNotApplyStateWhenApplyTransformOmitted() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack()
+
+        XCTAssertTrue(delegate.updatedCropStates.isEmpty)
+        XCTAssertEqual(stack.top, 1) // still pushed onto the stack
+    }
+
+    func testAddRegistersUndo() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertTrue(delegate.undoManager.canUndo)
+    }
+
+    func testAddEnablesResetForNormalTransform() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertEqual(delegate.resetEnableStates.last, true)
+    }
+
+    func testAddDisablesResetForResetTransform() {
+        let record = makeRecord(type: .resetTransforms, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertEqual(delegate.resetEnableStates.last, false)
+    }
+
+    func testAddIsNoOpWithoutDelegate() {
+        stack.transformDelegate = nil
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertEqual(stack.top, 0)
+        XCTAssertTrue(delegate.updatedCropStates.isEmpty)
+    }
+
+    // MARK: - Undo (removeAdjustmentFromStack)
+
+    func testUndoAppliesPreviousStateAndPopsStack() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertEqual(stack.top, 1)
+
+        record.removeAdjustmentFromStack()
+
+        // The most recent state pushed to the delegate is the "previous" one.
+        XCTAssertEqual(delegate.updatedCropStates.last?.degrees, 10)
+        XCTAssertEqual(stack.top, 0)
+    }
+
+    func testUndoDisablesResetWhenStackReturnsToBottom() {
+        let record = makeRecord(type: .transform, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        record.removeAdjustmentFromStack()
+        // Back at the bottom of a normal-transform stack => reset disabled.
+        XCTAssertEqual(delegate.resetEnableStates.last, false)
+    }
+
+    func testUndoEnablesResetForResetTransform() {
+        let record = makeRecord(type: .resetTransforms, previousDegrees: 10, currentDegrees: 20)
+        record.addAdjustmentToStack(NSNumber(value: true))
+        record.removeAdjustmentFromStack()
+        XCTAssertEqual(delegate.resetEnableStates.last, true)
+    }
+
+    func testUndoAboveBottomDoesNotTouchResetState() {
+        let first = makeRecord(type: .transform, previousDegrees: 1, currentDegrees: 2)
+        let second = makeRecord(type: .transform, previousDegrees: 3, currentDegrees: 4)
+        first.addAdjustmentToStack(NSNumber(value: true))
+        second.addAdjustmentToStack(NSNumber(value: true))
+        XCTAssertEqual(stack.top, 2)
+
+        let resetCallsBefore = delegate.resetEnableStates.count
+        second.removeAdjustmentFromStack()
+
+        // Still above the bottom (top == 1) and not a reset transform, so the
+        // reset-enable state is left untouched.
+        XCTAssertEqual(stack.top, 1)
+        XCTAssertEqual(delegate.resetEnableStates.count, resetCallsBefore)
+    }
+}


### PR DESCRIPTION
## What

Follow-up to #541. Adds unit tests for `TransformRecord`, the undo/redo record type behind the crop editor's history. Previously untested.

## Coverage (10 cases)

Using a real `TransformStack` and a fake `TransformDelegate`:

- **Redo** (`addAdjustmentToStack`) applies the *current* crop state, gated by the `applyTransform` flag, pushes onto the stack, and registers an undo action.
- **Undo** (`removeAdjustmentFromStack`) applies the *previous* crop state and pops the stack.
- **Reset-button enable state**: disabled when adding to / returning to the bottom of a normal stack, driven `true` for reset-type transforms, and left untouched when undoing above the bottom.
- **No-op** when the delegate is absent.

## Verification

Full suite green on iOS Simulator (iPhone 16, iOS 18.2): **273 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for transform undo/redo behavior and stack state updates.
  * Verified crop updates, undo/redo availability, and reset button enablement across common and edge cases.
  * Added checks to ensure behavior remains consistent when no transform handler is connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->