### PR TITLE
fix: confine crop box resizing within the content bounds

### DIFF
--- a/Sources/Mantis/CropView/CropViewModel.swift
+++ b/Sources/Mantis/CropView/CropViewModel.swift
@@ -182,13 +182,22 @@ final class CropViewModel: CropViewModelProtocol {
                                                                                   cropBoxFrame: cropBoxFrame)
             cropBoxLockedAspectFrameUpdater.updateCropBoxFrame(xDelta: xDelta, yDelta: yDelta)
             newCropBoxFrame = cropBoxLockedAspectFrameUpdater.cropBoxFrame
+
+            // A locked-ratio frame cannot be clamped edge by edge without
+            // breaking the ratio, so an update crossing the content frame
+            // (e.g. reaching under the toolbar) is rejected as a whole
+            guard contentFrame.insetBy(dx: -0.5, dy: -0.5).contains(newCropBoxFrame) else {
+                return cropBoxFrame
+            }
         } else {
             var cropBoxFreeAspectFrameUpdater = CropBoxFreeAspectFrameUpdater(tappedEdge: tappedEdge,
                                                                               contentFrame: contentFrame,
                                                                               cropOriginFrame: cropBoxOriginFrame,
                                                                               cropBoxFrame: cropBoxFrame)
             cropBoxFreeAspectFrameUpdater.updateCropBoxFrame(xDelta: xDelta, yDelta: yDelta)
-            newCropBoxFrame = cropBoxFreeAspectFrameUpdater.cropBoxFrame
+            // Confine the crop box within the content frame so it cannot
+            // extend under the toolbar or other surrounding controls
+            newCropBoxFrame = cropBoxFreeAspectFrameUpdater.cropBoxFrame.intersection(contentFrame)
         }
 
         return newCropBoxFrame

--- a/Tests/MantisTests/CropViewModelTests.swift
+++ b/Tests/MantisTests/CropViewModelTests.swift
@@ -166,17 +166,14 @@ final class CropViewModelTests: XCTestCase {
         viewModel.cropBoxOriginFrame = contentFrame
         
         // Test streching out the crop box from bottom left
+        // The crop box is already as large as the content frame, so it stays confined to it
         var touchPoint = CGPoint(x: 10, y: 210)
         var newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint, andContentFrame: contentFrame, aspectRatioLockEnabled: false)
-        XCTAssertTrue(newCropBoxFrame.width > contentFrame.width)
-        XCTAssertTrue(newCropBoxFrame.height > contentFrame.height)
-        XCTAssertNotEqual(newCropBoxFrame.width / newCropBoxFrame.height, contentFrame.width / contentFrame.height)
+        XCTAssertEqual(newCropBoxFrame, contentFrame)
 
         newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint, andContentFrame: contentFrame, aspectRatioLockEnabled: true)
-        XCTAssertTrue(newCropBoxFrame.width > contentFrame.width)
-        XCTAssertTrue(newCropBoxFrame.height > contentFrame.height)
-        XCTAssertEqual(newCropBoxFrame.width / newCropBoxFrame.height, contentFrame.width / contentFrame.height, accuracy: 0.1)
-        
+        XCTAssertEqual(newCropBoxFrame, contentFrame)
+
         // Test squizzing in the crop box from bottom left
         touchPoint = CGPoint(x: 20, y: 190)
         newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint, andContentFrame: contentFrame, aspectRatioLockEnabled: true)
@@ -185,6 +182,28 @@ final class CropViewModelTests: XCTestCase {
         XCTAssertEqual(newCropBoxFrame.width / newCropBoxFrame.height, contentFrame.width / contentFrame.height, accuracy: 0.1)
     }
     
+    func testGetNewCropBoxFrameIsConfinedToContentFrame() {
+        let contentFrame = CGRect(x: 20, y: 200, width: 100, height: 200)
+        let cropBox = CGRect(x: 40, y: 250, width: 60, height: 100)
+
+        viewModel.panOriginPoint = CGPoint(x: 70, y: 350)
+        viewModel.tappedEdge = .bottom
+        viewModel.cropBoxFrame = cropBox
+        viewModel.cropBoxOriginFrame = cropBox
+
+        // Drag the bottom edge far below the content frame (e.g. over the toolbar area)
+        let touchPoint = CGPoint(x: 70, y: 500)
+        var newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint, andContentFrame: contentFrame, aspectRatioLockEnabled: false)
+        XCTAssertEqual(newCropBoxFrame.maxY, contentFrame.maxY)
+        XCTAssertEqual(newCropBoxFrame.minY, cropBox.minY)
+        XCTAssertEqual(newCropBoxFrame.minX, cropBox.minX)
+        XCTAssertEqual(newCropBoxFrame.width, cropBox.width)
+
+        // With a locked ratio the whole update is rejected once it would cross the content frame
+        newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint, andContentFrame: contentFrame, aspectRatioLockEnabled: true)
+        XCTAssertEqual(newCropBoxFrame, cropBox)
+    }
+
     func testSetCropBoxFrame() {
         let refCropBox = CGRect(x: 20, y: 20, width: 100, height: 200)
         viewModel.fixedImageRatio = 0.9


### PR DESCRIPTION
## Summary

Addresses the toolbar-limit part of #382: the crop box could previously be dragged under the toolbar (and the attached rotation control) when the image was zoomed in.

**Root cause:** during a resize drag, the touch point is only confined to the image container. When the image is zoomed in, the image container extends beyond the visible content area, so the crop box could follow the finger past the content bounds. `getNewCropBoxFrame` only clamped the touch point on the top/left sides, and neither frame updater used the `contentFrame` it received for bounds checking.

**Fix** (in `CropViewModel.getNewCropBoxFrame`):
- **Free aspect ratio:** the new crop box frame is intersected with the content frame, so each edge independently stops at the content bounds.
- **Locked aspect ratio:** the frame cannot be clamped edge by edge without breaking the ratio, so an update that would cross the content frame is rejected as a whole (with a 0.5pt tolerance for floating-point jitter), consistent with how updates exceeding the image bounds are already rejected.

Since `getContentBounds()` already excludes the padding and the attached rotation control area, this also prevents the crop box from being dragged over the rotation dial.

## Tests

- Updated `testGetNewCropBoxFrame`, whose previous assertions documented the buggy behavior (crop box growing larger than the content frame), to assert the confined behavior.
- Added `testGetNewCropBoxFrameIsConfinedToContentFrame` covering both paths: free ratio (bottom edge stops at `contentFrame.maxY`) and locked ratio (out-of-bounds update rejected as a whole).
- Full suite passes: 274 tests, 0 failures (iPhone 16 simulator).

The remaining part of #382 (adjusting `zoomScale`/`contentOffset` to pull an off-screen image back into view while expanding the crop box) is intentionally out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Crop box resizing now stays within the visible content area more consistently.
  * When aspect ratio locking is enabled, invalid drags that would move the crop box outside the content area are now ignored.
  * Dragging at the edges now behaves more predictably when the crop box already matches the content bounds.

* **Tests**
  * Updated crop box behavior tests to match the new boundary handling.
  * Added coverage for drag interactions that exceed the content area with and without aspect ratio locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->