### PR TITLE
feat: zoom out to reveal more image while expanding the crop box

### DIFF
--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -50,7 +50,8 @@ class ViewController: UIViewController {
         let indicatorFrame = CGRect(origin: .zero, size: config.cropViewConfig.cropActivityIndicatorSize)
         config.cropViewConfig.cropActivityIndicator = CustomWaitingIndicator(frame: indicatorFrame)
         config.cropToolbarConfig.toolbarButtonOptions = [.clockwiseRotate, .reset, .ratio, .autoAdjust, .horizontallyFlip]
-        
+        config.cropViewConfig.enableZoomOutWhileExpandingCropBox = true
+
         if let transformation = transformation {
             config.cropViewConfig.presetTransformationType = .presetInfo(info: transformation)
         }

--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		AA000000000000000000AE01 /* AngleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000AE02 /* AngleTests.swift */; };
 		AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000BC02 /* RotationCalculatorTests.swift */; };
 		AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */; };
+		AA000000000000000000PB03 /* CropBoxPullBackCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000PB04 /* CropBoxPullBackCalculatorTests.swift */; };
 		AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */; };
 		AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */; };
 		AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000FR02 /* FixedRatioManagerTests.swift */; };
@@ -127,6 +128,7 @@
 		OBJ_120 /* XCTestManifests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_53 /* XCTestManifests.swift */; };
 		OBJ_122 /* Mantis.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "Mantis::Mantis::Product" /* Mantis.framework */; };
 		OBJ_69 /* CropBoxFreeAspectFrameUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* CropBoxFreeAspectFrameUpdater.swift */; };
+		AA000000000000000000PB01 /* CropBoxPullBackCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000000000000000000PB02 /* CropBoxPullBackCalculator.swift */; };
 		OBJ_70 /* CropBoxLockedAspectFrameUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* CropBoxLockedAspectFrameUpdater.swift */; };
 		OBJ_71 /* CropMaskViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* CropMaskViewManager.swift */; };
 		OBJ_72 /* CropAuxiliaryIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* CropAuxiliaryIndicatorView.swift */; };
@@ -253,6 +255,7 @@
 		AA000000000000000000AE02 /* AngleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AngleTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000BC02 /* RotationCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotationCalculatorTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxFreeAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
+		AA000000000000000000PB04 /* CropBoxPullBackCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxPullBackCalculatorTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxLockedAspectFrameUpdaterTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreGraphicsExtensionsTests.swift; sourceTree = "<group>"; };
 		AA000000000000000000FR02 /* FixedRatioManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedRatioManagerTests.swift; sourceTree = "<group>"; };
@@ -299,6 +302,7 @@
 		"Mantis::MantisTests::Product" /* MantisTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = MantisTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		OBJ_10 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		OBJ_12 /* CropBoxFreeAspectFrameUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxFreeAspectFrameUpdater.swift; sourceTree = "<group>"; };
+		AA000000000000000000PB02 /* CropBoxPullBackCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxPullBackCalculator.swift; sourceTree = "<group>"; };
 		OBJ_13 /* CropBoxLockedAspectFrameUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropBoxLockedAspectFrameUpdater.swift; sourceTree = "<group>"; };
 		OBJ_14 /* CropMaskViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropMaskViewManager.swift; sourceTree = "<group>"; };
 		OBJ_15 /* CropAuxiliaryIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropAuxiliaryIndicatorView.swift; sourceTree = "<group>"; };
@@ -451,6 +455,7 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_12 /* CropBoxFreeAspectFrameUpdater.swift */,
+				AA000000000000000000PB02 /* CropBoxPullBackCalculator.swift */,
 				OBJ_13 /* CropBoxLockedAspectFrameUpdater.swift */,
 				OBJ_14 /* CropMaskViewManager.swift */,
 				OBJ_15 /* CropAuxiliaryIndicatorView.swift */,
@@ -591,6 +596,7 @@
 				AA000000000000000000AE02 /* AngleTests.swift */,
 				AA000000000000000000BC02 /* RotationCalculatorTests.swift */,
 				AA000000000000000000CF02 /* CropBoxFreeAspectFrameUpdaterTests.swift */,
+				AA000000000000000000PB04 /* CropBoxPullBackCalculatorTests.swift */,
 				AA000000000000000000CL02 /* CropBoxLockedAspectFrameUpdaterTests.swift */,
 				AA000000000000000000CG02 /* CoreGraphicsExtensionsTests.swift */,
 				AA000000000000000000FR02 /* FixedRatioManagerTests.swift */,
@@ -848,6 +854,7 @@
 				AA000000000000000000AE01 /* AngleTests.swift in Sources */,
 				AA000000000000000000BC01 /* RotationCalculatorTests.swift in Sources */,
 				AA000000000000000000CF01 /* CropBoxFreeAspectFrameUpdaterTests.swift in Sources */,
+				AA000000000000000000PB03 /* CropBoxPullBackCalculatorTests.swift in Sources */,
 				AA000000000000000000CL01 /* CropBoxLockedAspectFrameUpdaterTests.swift in Sources */,
 				AA000000000000000000CG01 /* CoreGraphicsExtensionsTests.swift in Sources */,
 				AA000000000000000000FR01 /* FixedRatioManagerTests.swift in Sources */,
@@ -885,6 +892,7 @@
 			files = (
 				66F439882978376F00728B52 /* RotationDialViewModelProtocol.swift in Sources */,
 				OBJ_69 /* CropBoxFreeAspectFrameUpdater.swift in Sources */,
+				AA000000000000000000PB01 /* CropBoxPullBackCalculator.swift in Sources */,
 				OBJ_70 /* CropBoxLockedAspectFrameUpdater.swift in Sources */,
 				OBJ_71 /* CropMaskViewManager.swift in Sources */,
 				66100E11294BAEB6001C8593 /* CropScrollViewProtocol.swift in Sources */,

--- a/Sources/Mantis/CropView/CropBoxPullBackCalculator.swift
+++ b/Sources/Mantis/CropView/CropBoxPullBackCalculator.swift
@@ -1,0 +1,223 @@
+//
+//  CropBoxPullBackCalculator.swift
+//  Mantis
+//
+//  Created by Yingtao Guo on 7/10/26.
+//
+
+import UIKit
+
+/**
+ Computes the "pull back" applied while the user keeps dragging a crop box
+ edge outward after the crop box has reached the content bounds.
+
+ Instead of stopping, the image zooms out (anchored at the edge/corner
+ opposite to the dragged one) so more of the image is revealed, until the
+ image edge meets the dragged crop box edge — similar to the Photos app.
+
+ The crop region (in image points) is the source of truth:
+ - Finger movement is converted into crop region growth at the zoom scale
+   captured when the gesture began, so the mapping stays stable and the
+   pull back is fully reversible within one gesture.
+ - The zoom scale is then whatever is needed to display that region inside
+   the available space between the anchored edge and the content bounds.
+ - The axis that is not being dragged keeps its crop region length, so its
+   crop box length shrinks together with the zoom scale.
+ */
+enum CropBoxPullBackCalculator {
+    struct Input {
+        var tappedEdge: CropViewAuxiliaryIndicatorHandleType
+        var desiredFrame: CGRect
+        var cropOriginFrame: CGRect
+        var contentBounds: CGRect
+        var imageFrameInView: CGRect
+        var startZoomScale: CGFloat
+        var currentZoomScale: CGFloat
+        var minimumCropBoxSize: CGFloat
+    }
+
+    struct Result: Equatable {
+        var zoomScale: CGFloat
+        var cropBoxFrame: CGRect
+    }
+
+    private struct Axis {
+        var direction: Int // 1: max edge dragged, -1: min edge dragged, 0: not dragged
+        var originMin: CGFloat
+        var originMax: CGFloat
+        var desiredLength: CGFloat
+        var boundsMin: CGFloat
+        var boundsMax: CGFloat
+        var imageMin: CGFloat
+        var imageMax: CGFloat
+    }
+
+    private struct AxisPlan {
+        var cropRegionLength: CGFloat // in image points
+        var zoomCap: CGFloat // pins the dragged edge at the content bounds
+        var zoomFloor: CGFloat // protects minimumCropBoxSize
+        var availableLength: CGFloat // in view points
+    }
+
+    private static let epsilon: CGFloat = 1e-5
+
+    /// Returns nil when no pull back is needed, in which case the regular
+    /// crop box update path should be used.
+    static func calculate(_ input: Input) -> Result? {
+        let origin = input.cropOriginFrame
+
+        guard input.startZoomScale > 0, input.currentZoomScale > 0,
+              origin.width > 0, origin.height > 0 else {
+            return nil
+        }
+
+        let xDirection = horizontalDragDirection(of: input.tappedEdge)
+        let yDirection = verticalDragDirection(of: input.tappedEdge)
+
+        guard xDirection != 0 || yDirection != 0 else {
+            return nil
+        }
+
+        let xAxis = Axis(direction: xDirection,
+                         originMin: origin.minX,
+                         originMax: origin.maxX,
+                         desiredLength: input.desiredFrame.width,
+                         boundsMin: input.contentBounds.minX,
+                         boundsMax: input.contentBounds.maxX,
+                         imageMin: input.imageFrameInView.minX,
+                         imageMax: input.imageFrameInView.maxX)
+        let yAxis = Axis(direction: yDirection,
+                         originMin: origin.minY,
+                         originMax: origin.maxY,
+                         desiredLength: input.desiredFrame.height,
+                         boundsMin: input.contentBounds.minY,
+                         boundsMax: input.contentBounds.maxY,
+                         imageMin: input.imageFrameInView.minY,
+                         imageMax: input.imageFrameInView.maxY)
+
+        guard let xPlan = makeAxisPlan(for: xAxis, with: input),
+              let yPlan = makeAxisPlan(for: yAxis, with: input) else {
+            return nil
+        }
+
+        var zoomScale = min(input.startZoomScale, xPlan.zoomCap, yPlan.zoomCap)
+        zoomScale = max(zoomScale, xPlan.zoomFloor, yPlan.zoomFloor)
+        zoomScale = min(zoomScale, input.startZoomScale)
+
+        let needsPullBack = zoomScale < input.startZoomScale - epsilon
+        let needsRestore = input.currentZoomScale < input.startZoomScale - epsilon
+
+        guard needsPullBack || needsRestore else {
+            return nil
+        }
+
+        let width = min(xPlan.cropRegionLength * zoomScale, xPlan.availableLength)
+        let height = min(yPlan.cropRegionLength * zoomScale, yPlan.availableLength)
+
+        let cropBoxFrame = CGRect(x: anchoredPosition(for: xAxis, length: width),
+                                  y: anchoredPosition(for: yAxis, length: height),
+                                  width: width,
+                                  height: height)
+
+        return Result(zoomScale: zoomScale, cropBoxFrame: cropBoxFrame)
+    }
+
+    private static func makeAxisPlan(for axis: Axis, with input: Input) -> AxisPlan? {
+        if axis.direction == 0 {
+            // The crop region length stays fixed on this axis, so the crop
+            // box length shrinks proportionally with the zoom scale
+            let regionLength = (axis.originMax - axis.originMin) / input.startZoomScale
+
+            guard regionLength > 0 else {
+                return nil
+            }
+
+            return AxisPlan(cropRegionLength: regionLength,
+                            zoomCap: .greatestFiniteMagnitude,
+                            zoomFloor: input.minimumCropBoxSize / regionLength,
+                            availableLength: .greatestFiniteMagnitude)
+        }
+
+        let desiredLength = max(axis.desiredLength, input.minimumCropBoxSize)
+        let availableLength = axis.direction > 0
+            ? axis.boundsMax - axis.originMin
+            : axis.originMax - axis.boundsMin
+        let imageAvailableLength = (axis.direction > 0
+            ? axis.imageMax - axis.originMin
+            : axis.originMax - axis.imageMin) / input.currentZoomScale
+
+        guard availableLength > 0, imageAvailableLength > 0 else {
+            return nil
+        }
+
+        let regionLength = min(desiredLength / input.startZoomScale, imageAvailableLength)
+
+        guard regionLength > 0 else {
+            return nil
+        }
+
+        return AxisPlan(cropRegionLength: regionLength,
+                        zoomCap: availableLength / regionLength,
+                        zoomFloor: input.minimumCropBoxSize / regionLength,
+                        availableLength: availableLength)
+    }
+
+    private static func anchoredPosition(for axis: Axis, length: CGFloat) -> CGFloat {
+        switch axis.direction {
+        case 1:
+            return axis.originMin
+        case -1:
+            return axis.originMax - length
+        default:
+            return (axis.originMin + axis.originMax - length) / 2
+        }
+    }
+
+    static func horizontalDragDirection(of tappedEdge: CropViewAuxiliaryIndicatorHandleType) -> Int {
+        switch tappedEdge {
+        case .right, .topRight, .bottomRight:
+            return 1
+        case .left, .topLeft, .bottomLeft:
+            return -1
+        default:
+            return 0
+        }
+    }
+
+    static func verticalDragDirection(of tappedEdge: CropViewAuxiliaryIndicatorHandleType) -> Int {
+        switch tappedEdge {
+        case .bottom, .bottomLeft, .bottomRight:
+            return 1
+        case .top, .topLeft, .topRight:
+            return -1
+        default:
+            return 0
+        }
+    }
+
+    /// The view point of the edge/corner opposite to the dragged one. The
+    /// image point under it stays fixed at this view point during pull back.
+    static func anchorPoint(for tappedEdge: CropViewAuxiliaryIndicatorHandleType, in frame: CGRect) -> CGPoint {
+        let xPosition: CGFloat
+        switch horizontalDragDirection(of: tappedEdge) {
+        case 1:
+            xPosition = frame.minX
+        case -1:
+            xPosition = frame.maxX
+        default:
+            xPosition = frame.midX
+        }
+
+        let yPosition: CGFloat
+        switch verticalDragDirection(of: tappedEdge) {
+        case 1:
+            yPosition = frame.minY
+        case -1:
+            yPosition = frame.maxY
+        default:
+            yPosition = frame.midY
+        }
+
+        return CGPoint(x: xPosition, y: yPosition)
+    }
+}

--- a/Sources/Mantis/CropView/CropView+Touches.swift
+++ b/Sources/Mantis/CropView/CropView+Touches.swift
@@ -64,6 +64,7 @@ extension CropView {
         
         let point = touch.location(in: self)
         viewModel.prepareForCrop(byTouchPoint: point)
+        prepareForPullBackIfNeeded()
     }
     
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/Sources/Mantis/CropView/CropView.swift
+++ b/Sources/Mantis/CropView/CropView.swift
@@ -67,6 +67,14 @@ final class CropView: UIView {
     /// or the anchor-point restoration path (user has customized the crop region).
     /// Skew-only changes do NOT set this flag.
     var hasManuallyAdjustedCropBox = false
+
+    /// State captured at the beginning of a crop box resize gesture, used by
+    /// the pull back behavior (enableZoomOutWhileExpandingCropBox) to keep the
+    /// zoom mapping stable and reversible within one gesture.
+    var resizeGestureStartZoomScale: CGFloat = 1
+    var resizeGestureStartMinimumZoomScale: CGFloat = 1
+    var resizeGestureAnchorPointInView: CGPoint = .zero
+    var resizeGestureAnchorPointInContainer: CGPoint = .zero
     var forceFixedRatio = false
     var checkForForceFixedRatioFlag = false
     let cropViewConfig: CropViewConfig
@@ -318,8 +326,15 @@ final class CropView: UIView {
     
     func updateCropBoxFrame(withTouchPoint touchPoint: CGPoint) {
         let imageContainerRect = imageContainer.convert(imageContainer.bounds, to: self)
-        let touchPoint = confineTouchPoint(touchPoint, in: imageContainerRect)
         let contentBounds = getContentBounds()
+
+        // The pull back path uses the unconfined touch point: the crop region
+        // clamp inside the calculator already stops at the image edge exactly
+        if updateCropBoxFrameWithPullBackIfNeeded(touchPoint: touchPoint, contentBounds: contentBounds) {
+            return
+        }
+
+        let touchPoint = confineTouchPoint(touchPoint, in: imageContainerRect)
         let cropViewMinimumBoxSize = cropViewConfig.minimumCropBoxSize
         let newCropBoxFrame = viewModel.getNewCropBoxFrame(withTouchPoint: touchPoint,
                                                            andContentFrame: contentBounds,
@@ -370,6 +385,79 @@ final class CropView: UIView {
             
             viewModel.cropBoxFrame = CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
         }
+    }
+}
+
+// MARK: - Pull back (zoom out while expanding the crop box)
+extension CropView {
+    private func isPullBackEnabled() -> Bool {
+        cropViewConfig.enableZoomOutWhileExpandingCropBox
+            && !aspectRatioLockEnabled
+            && viewModel.degrees == 0
+            && viewModel.horizontalSkewDegrees == 0
+            && viewModel.verticalSkewDegrees == 0
+            && viewModel.tappedEdge != .none
+    }
+
+    /// Captures the gesture start state used by the pull back behavior.
+    /// Called from touchesBegan after the view model has been prepared.
+    func prepareForPullBackIfNeeded() {
+        guard isPullBackEnabled() else {
+            return
+        }
+
+        resizeGestureStartZoomScale = cropWorkbenchView.zoomScale
+        resizeGestureStartMinimumZoomScale = cropWorkbenchView.minimumZoomScale
+        resizeGestureAnchorPointInView = CropBoxPullBackCalculator.anchorPoint(for: viewModel.tappedEdge,
+                                                                               in: viewModel.cropBoxOriginFrame)
+        resizeGestureAnchorPointInContainer = imageContainer.convert(resizeGestureAnchorPointInView, from: self)
+    }
+
+    private func updateCropBoxFrameWithPullBackIfNeeded(touchPoint: CGPoint, contentBounds: CGRect) -> Bool {
+        guard isPullBackEnabled() else {
+            return false
+        }
+
+        let xDelta = ceil(touchPoint.x - viewModel.panOriginPoint.x)
+        let yDelta = ceil(touchPoint.y - viewModel.panOriginPoint.y)
+
+        var frameUpdater = CropBoxFreeAspectFrameUpdater(tappedEdge: viewModel.tappedEdge,
+                                                         contentFrame: contentBounds,
+                                                         cropOriginFrame: viewModel.cropBoxOriginFrame,
+                                                         cropBoxFrame: viewModel.cropBoxFrame)
+        frameUpdater.updateCropBoxFrame(xDelta: xDelta, yDelta: yDelta)
+
+        let input = CropBoxPullBackCalculator.Input(tappedEdge: viewModel.tappedEdge,
+                                                    desiredFrame: frameUpdater.cropBoxFrame,
+                                                    cropOriginFrame: viewModel.cropBoxOriginFrame,
+                                                    contentBounds: contentBounds,
+                                                    imageFrameInView: imageContainer.convert(imageContainer.bounds, to: self),
+                                                    startZoomScale: resizeGestureStartZoomScale,
+                                                    currentZoomScale: cropWorkbenchView.zoomScale,
+                                                    minimumCropBoxSize: cropViewConfig.minimumCropBoxSize)
+
+        guard let result = CropBoxPullBackCalculator.calculate(input) else {
+            return false
+        }
+
+        applyPullBack(result)
+        return true
+    }
+
+    private func applyPullBack(_ result: CropBoxPullBackCalculator.Result) {
+        cropWorkbenchView.minimumZoomScale = min(resizeGestureStartMinimumZoomScale, result.zoomScale)
+        cropWorkbenchView.zoomScale = result.zoomScale
+
+        // Keep the image point that was under the anchor edge/corner at the
+        // gesture start fixed at that same view position
+        let anchorNowInView = imageContainer.convert(resizeGestureAnchorPointInContainer, to: self)
+        let anchorNowInScrollView = cropWorkbenchView.convert(anchorNowInView, from: self)
+        let anchorTargetInScrollView = cropWorkbenchView.convert(resizeGestureAnchorPointInView, from: self)
+        cropWorkbenchView.contentOffset = CGPoint(x: cropWorkbenchView.contentOffset.x + anchorNowInScrollView.x - anchorTargetInScrollView.x,
+                                                  y: cropWorkbenchView.contentOffset.y + anchorNowInScrollView.y - anchorTargetInScrollView.y)
+
+        viewModel.cropBoxFrame = result.cropBoxFrame
+        isManuallyZoomed = true
     }
 }
 

--- a/Sources/Mantis/CropViewConfig.swift
+++ b/Sources/Mantis/CropViewConfig.swift
@@ -68,6 +68,15 @@ public struct CropViewConfig {
     /// When true, enables perspective correction with straighten / horizontal skew / vertical skew
     /// adjustments similar to Apple Photos app.
     public var enablePerspectiveCorrection: Bool = false
+
+    /// When true and the image is zoomed in, dragging a crop box edge outward
+    /// keeps working after the crop box reaches the content bounds: the image
+    /// zooms out to reveal more of itself until its edge meets the dragged
+    /// crop box edge, similar to the Photos app.
+    ///
+    /// Currently only takes effect with a free (unlocked) aspect ratio and
+    /// when no free-angle rotation or perspective correction is applied.
+    public var enableZoomOutWhileExpandingCropBox = false
     
     /// Maximum pixel count (width × height) for input images before enabling large image mode.
     /// When set to a value > 0 and the input image exceeds this limit, Mantis will:

--- a/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/ContentView.swift
@@ -159,6 +159,9 @@ struct ContentView: View {
             Button("Perspective Correction") {
                 cropperOptions = DeclarativeCropperOptions(enablesPerspectiveCorrection: true)
             }.font(.title)
+            Button("Zoom Out While Expanding") {
+                cropperOptions = DeclarativeCropperOptions(zoomsOutWhileExpandingCropBox: true)
+            }.font(.title)
             Button("Legacy Binding API") {
                 showingLegacyCropper = true
             }.font(.title)

--- a/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
+++ b/SwiftUIExample/MantisSwiftUIExample/DeclarativeCropperDemoView.swift
@@ -32,6 +32,9 @@ struct DeclarativeCropperOptions: Identifiable {
     var showsRotationControl = true
     var usesSlideDial = false
     var enablesPerspectiveCorrection = false
+    /// Zoom the image out when a crop box edge is dragged past the content
+    /// bounds, revealing more of the image (Photos-app-like behavior).
+    var zoomsOutWhileExpandingCropBox = false
     /// Reopen restored to the last saved crop state, like the UIKit
     /// example's normal entry.
     var restoresLastTransformation = false
@@ -95,6 +98,12 @@ struct DeclarativeCropperView: View {
         if options.usesSlideDial {
             cropper = cropper.configure { config in
                 config.cropViewConfig.builtInRotationControlViewType = .slideDial()
+            }
+        }
+
+        if options.zoomsOutWhileExpandingCropBox {
+            cropper = cropper.configure { config in
+                config.cropViewConfig.enableZoomOutWhileExpandingCropBox = true
             }
         }
 

--- a/Tests/MantisTests/CropBoxPullBackCalculatorTests.swift
+++ b/Tests/MantisTests/CropBoxPullBackCalculatorTests.swift
@@ -1,0 +1,157 @@
+//
+//  CropBoxPullBackCalculatorTests.swift
+//  MantisTests
+//
+//  Created by Yingtao Guo on 7/10/26.
+//
+
+import XCTest
+@testable import Mantis
+
+final class CropBoxPullBackCalculatorTests: XCTestCase {
+    // A 200x200 crop box centered in a 500x500 content area, on an image
+    // that extends well beyond the content bounds (zoomed in), at zoom 2
+    private func makeInput(tappedEdge: CropViewAuxiliaryIndicatorHandleType,
+                           desiredFrame: CGRect,
+                           imageFrameInView: CGRect = CGRect(x: -300, y: -300, width: 1200, height: 1200),
+                           currentZoomScale: CGFloat = 2,
+                           minimumCropBoxSize: CGFloat = 42) -> CropBoxPullBackCalculator.Input {
+        CropBoxPullBackCalculator.Input(tappedEdge: tappedEdge,
+                                        desiredFrame: desiredFrame,
+                                        cropOriginFrame: CGRect(x: 100, y: 100, width: 200, height: 200),
+                                        contentBounds: CGRect(x: 0, y: 0, width: 500, height: 500),
+                                        imageFrameInView: imageFrameInView,
+                                        startZoomScale: 2,
+                                        currentZoomScale: currentZoomScale,
+                                        minimumCropBoxSize: minimumCropBoxSize)
+    }
+
+    private func assertEqual(_ result: CropBoxPullBackCalculator.Result?,
+                             zoomScale: CGFloat,
+                             cropBoxFrame: CGRect,
+                             accuracy: CGFloat = 1e-9,
+                             file: StaticString = #filePath,
+                             line: UInt = #line) {
+        guard let result = result else {
+            XCTFail("Expected a pull back result", file: file, line: line)
+            return
+        }
+
+        XCTAssertEqual(result.zoomScale, zoomScale, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(result.cropBoxFrame.minX, cropBoxFrame.minX, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(result.cropBoxFrame.minY, cropBoxFrame.minY, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(result.cropBoxFrame.width, cropBoxFrame.width, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(result.cropBoxFrame.height, cropBoxFrame.height, accuracy: accuracy, file: file, line: line)
+    }
+
+    func testNoPullBackWhenDesiredFrameFitsInContentBounds() {
+        let input = makeInput(tappedEdge: .right,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 250, height: 200))
+        XCTAssertNil(CropBoxPullBackCalculator.calculate(input))
+    }
+
+    func testNoPullBackWhenNoEdgeIsTapped() {
+        let input = makeInput(tappedEdge: .none,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 500, height: 200))
+        XCTAssertNil(CropBoxPullBackCalculator.calculate(input))
+    }
+
+    func testRightEdgeOvershootZoomsOutAnchoredAtLeftEdge() {
+        // Finger wants a 500pt wide box but only 400pt is available from the
+        // anchored left edge to the content bounds. The 250 image points that
+        // the virtual box would cover get squeezed into 400pt: zoom 400/250
+        let input = makeInput(tappedEdge: .right,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 500, height: 200))
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        // The vertical crop region is unchanged (100 image points), so the
+        // box height shrinks with the zoom (100 * 1.6), centered vertically
+        assertEqual(result,
+                    zoomScale: 1.6,
+                    cropBoxFrame: CGRect(x: 100, y: 120, width: 400, height: 160))
+    }
+
+    func testLeftEdgeOvershootZoomsOutAnchoredAtRightEdge() {
+        let input = makeInput(tappedEdge: .left,
+                              desiredFrame: CGRect(x: -300, y: 100, width: 600, height: 200),
+                              imageFrameInView: CGRect(x: -500, y: -300, width: 1400, height: 1200))
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        // Available space from the anchored right edge (300) to the content
+        // bounds left edge (0) is 300pt for 300 image points: zoom 1
+        assertEqual(result,
+                    zoomScale: 1,
+                    cropBoxFrame: CGRect(x: 0, y: 150, width: 300, height: 100))
+    }
+
+    func testZoomOutStopsAtImageEdge() {
+        // The image only has 300 image points from the anchor to its right
+        // edge, so the crop region is capped there even though the finger
+        // asks for 400: zoom 400/300
+        let input = makeInput(tappedEdge: .right,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 800, height: 200),
+                              imageFrameInView: CGRect(x: -300, y: -300, width: 1000, height: 1200))
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        let expectedZoom: CGFloat = 400.0 / 300.0
+        assertEqual(result,
+                    zoomScale: expectedZoom,
+                    cropBoxFrame: CGRect(x: 100,
+                                         y: 200 - 50 * expectedZoom,
+                                         width: 400,
+                                         height: 100 * expectedZoom))
+    }
+
+    func testZoomRestoresWhenFingerMovesBackInsideContentBounds() {
+        // Mid pull back (current zoom 1.6), the finger moves back to a
+        // position that fits: the zoom returns to the start zoom and the crop
+        // box follows the finger again
+        let input = makeInput(tappedEdge: .right,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 300, height: 200),
+                              imageFrameInView: CGRect(x: -240, y: -240, width: 960, height: 960),
+                              currentZoomScale: 1.6)
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        assertEqual(result,
+                    zoomScale: 2,
+                    cropBoxFrame: CGRect(x: 100, y: 100, width: 300, height: 200))
+    }
+
+    func testZoomOutStopsWhenPerpendicularAxisReachesMinimumCropBoxSize() {
+        // The vertical box length is 100 image points * zoom; it may not
+        // shrink below minimumCropBoxSize (100pt), so zoom stops at 1 even
+        // though pinning the right edge would want zoom 0.5
+        let input = makeInput(tappedEdge: .right,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 1600, height: 200),
+                              imageFrameInView: CGRect(x: -300, y: -300, width: 2000, height: 1200),
+                              minimumCropBoxSize: 100)
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        assertEqual(result,
+                    zoomScale: 1,
+                    cropBoxFrame: CGRect(x: 100, y: 150, width: 400, height: 100))
+    }
+
+    func testCornerOvershootZoomsOutAnchoredAtOppositeCorner() {
+        let input = makeInput(tappedEdge: .bottomRight,
+                              desiredFrame: CGRect(x: 100, y: 100, width: 500, height: 500))
+        let result = CropBoxPullBackCalculator.calculate(input)
+
+        assertEqual(result,
+                    zoomScale: 1.6,
+                    cropBoxFrame: CGRect(x: 100, y: 100, width: 400, height: 400))
+    }
+
+    func testAnchorPointIsOppositeToTappedEdge() {
+        let frame = CGRect(x: 100, y: 100, width: 200, height: 200)
+
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .right, in: frame), CGPoint(x: 100, y: 200))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .left, in: frame), CGPoint(x: 300, y: 200))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .top, in: frame), CGPoint(x: 200, y: 300))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .bottom, in: frame), CGPoint(x: 200, y: 100))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .topLeft, in: frame), CGPoint(x: 300, y: 300))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .topRight, in: frame), CGPoint(x: 100, y: 300))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .bottomLeft, in: frame), CGPoint(x: 300, y: 100))
+        XCTAssertEqual(CropBoxPullBackCalculator.anchorPoint(for: .bottomRight, in: frame), CGPoint(x: 100, y: 100))
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining part of #382 (phase 1). Stacked on #543 — please merge that first; this PR's base is the `fix/382-confine-crop-box-to-content-bounds` branch and can be retargeted to `master` once #543 lands.

After #543, dragging a crop box edge outward stops at the content bounds, and when the image is zoomed in, the off-screen part of the image can never be included in the crop by edge dragging alone (the release-time re-fit only ever zooms in). This PR adds the Photos-style behavior: keep dragging past the boundary and the image zooms out to reveal more of itself.

## Behavior

- Opt-in via `CropViewConfig.enableZoomOutWhileExpandingCropBox` (default `false`, so existing behavior is completely unchanged unless enabled).
- Once the dragged edge reaches the content bounds, the image zooms out anchored at the opposite edge/corner, until the image edge meets the dragged crop box edge.
- The non-dragged axis keeps its crop region, so its crop box length shrinks together with the zoom — the "opposite axis shrink" described in #382, which is also geometrically required to keep the crop box covered by the image.
- Fully reversible within a gesture: moving the finger back restores the zoom.
- `minimumCropBoxSize` is respected: the zoom-out pauses instead of shrinking the perpendicular axis below the minimum.
- On release, the existing `adjustUIForNewCrop` path re-inscribes the crop box and recomputes the minimum zoom scale, so undo/redo and transform records work unchanged.

## Scope (phase 1)

Takes effect only with a free (unlocked) aspect ratio, no free-angle rotation (`degrees == 0`) and no perspective correction. 90° step rotations and flips are supported — the content offset re-anchoring goes through UIKit coordinate conversion, which handles the workbench view transforms. Locked aspect ratios and free-angle rotation keep the stop-at-bounds behavior and can be added in a later phase.

## Implementation

- `CropBoxPullBackCalculator` (new): a pure function computing the target zoom scale and crop box frame from the gesture start state. The crop region in image points is the source of truth; finger movement converts to region growth at the gesture-start zoom scale, clamped to the image edge.
- `CropView`: captures gesture start state (zoom scale, minimum zoom scale, anchor point) in `touchesBegan`; in `touchesMoved` the pull back path applies zoom + re-anchored content offset + crop box frame, and falls through to the regular path whenever no pull back is needed.
- Demo: the flag is enabled in the Example app's "Normal" entry for easy manual testing.

## Tests

- 9 new unit tests for `CropBoxPullBackCalculator` (overshoot on edge/corner, image edge clamp, reversibility, minimum crop box size floor, anchor points).
- Full suite passes: 283 tests, 0 failures (iPhone 16 simulator). SwiftLint clean. Framework target and Example app both build.

## Manual testing suggestion

Run the Example app → "Normal" entry → pinch to zoom into the image → drag a crop box edge outward past the boundary and observe the image zooming out until its edge arrives; drag back to see it restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)