### PR TITLE
refactor: drop pre-iOS-13 hand-drawn toolbar icon fallbacks

### DIFF
--- a/Mantis.xcodeproj/project.pbxproj
+++ b/Mantis.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		5F7D22AE245BCA8D0015A0D5 /* CropToolbarProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7D22AD245BCA8D0015A0D5 /* CropToolbarProtocol.swift */; };
 		5FCE938724834C57002BBE65 /* ToolbarButtonOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCE938624834C57002BBE65 /* ToolbarButtonOptions.swift */; };
 		660D4F3A298C01D100C4E11A /* CropToolbarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D4F39298C01D100C4E11A /* CropToolbarTests.swift */; };
+		BB00000000000000000000B1 /* ToolBarButtonImageBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000000B2 /* ToolBarButtonImageBuilderTests.swift */; };
 		660D4F41298C08FA00C4E11A /* CropViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D4F40298C08FA00C4E11A /* CropViewControllerTests.swift */; };
 		660D4F45298CBD2500C4E11A /* CropViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D4F44298CBD2500C4E11A /* CropViewTests.swift */; };
 		660D4F57298CDA8C00C4E11A /* TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 660D4F56298CDA8C00C4E11A /* TestHelper.swift */; };
@@ -189,6 +190,7 @@
 		5F7D22AD245BCA8D0015A0D5 /* CropToolbarProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CropToolbarProtocol.swift; sourceTree = "<group>"; };
 		5FCE938624834C57002BBE65 /* ToolbarButtonOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarButtonOptions.swift; sourceTree = "<group>"; };
 		660D4F39298C01D100C4E11A /* CropToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropToolbarTests.swift; sourceTree = "<group>"; };
+		BB00000000000000000000B2 /* ToolBarButtonImageBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolBarButtonImageBuilderTests.swift; sourceTree = "<group>"; };
 		660D4F3C298C06A800C4E11A /* FakeCropToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCropToolbar.swift; sourceTree = "<group>"; };
 		660D4F3E298C079600C4E11A /* FakeCropViewControllerDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeCropViewControllerDelegate.swift; sourceTree = "<group>"; };
 		660D4F40298C08FA00C4E11A /* CropViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CropViewControllerTests.swift; sourceTree = "<group>"; };
@@ -571,6 +573,7 @@
 				66F439892978539700728B52 /* RotationDialViewModelTests.swift */,
 				66F4398F2979472C00728B52 /* CropViewModelTests.swift */,
 				660D4F39298C01D100C4E11A /* CropToolbarTests.swift */,
+				BB00000000000000000000B2 /* ToolBarButtonImageBuilderTests.swift */,
 				660D4F40298C08FA00C4E11A /* CropViewControllerTests.swift */,
 				660D4F44298CBD2500C4E11A /* CropViewTests.swift */,
 				660D4F56298CDA8C00C4E11A /* TestHelper.swift */,
@@ -863,6 +866,7 @@
 				660D4F60298F982200C4E11A /* FakeCropView.swift in Sources */,
 				660D4F45298CBD2500C4E11A /* CropViewTests.swift in Sources */,
 				660D4F3A298C01D100C4E11A /* CropToolbarTests.swift in Sources */,
+				BB00000000000000000000B1 /* ToolBarButtonImageBuilderTests.swift in Sources */,
 				660D4F65298F983700C4E11A /* FakeCropMaskViewManager.swift in Sources */,
 				660D4F5B298D524A00C4E11A /* RotateDialTests.swift in Sources */,
 				66F439902979472C00728B52 /* CropViewModelTests.swift in Sources */,

--- a/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
+++ b/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
@@ -28,125 +28,13 @@
 
 import UIKit
 
+// Hand-drawn fallbacks for toolbar icons that have no SF Symbol equivalent.
+// The rest of the icons use `UIImage(systemName:)` directly (see
+// ToolBarButtonImageBuilder), which is always available on the iOS 15 minimum.
 extension ToolBarButtonImageBuilder {
-    static func drawRotateCCWImage() -> UIImage? {
-        var rotateImage: UIImage?
-        
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: 18, height: 21), false, 0.0)
-        
-        //// Draw rectangle
-        let rectanglePath = UIBezierPath(rect: CGRect(x: 0, y: 9, width: 12, height: 12))
-        UIColor.white.setFill()
-        rectanglePath.fill()
-        
-        //// Draw triangle
-        let trianglePath = UIBezierPath()
-        trianglePath.move(to: CGPoint(x: 5, y: 3))
-        trianglePath.addLine(to: CGPoint(x: 10, y: 6))
-        trianglePath.addLine(to: CGPoint(x: 10, y: 0))
-        trianglePath.addLine(to: CGPoint(x: 5, y: 3))
-        trianglePath.close()
-        UIColor.white.setFill()
-        trianglePath.fill()
-        
-        //// Bezier Drawing
-        let bezierPath = UIBezierPath()
-        bezierPath.move(to: CGPoint(x: 10, y: 3))
-        
-        bezierPath.addCurve(to: CGPoint(x: 17.5, y: 11), controlPoint1: CGPoint(x: 15, y: 3), controlPoint2: CGPoint(x: 17.5, y: 5.91))
-        UIColor.white.setStroke()
-        bezierPath.lineWidth = 1
-        bezierPath.stroke()
-        rotateImage = UIGraphicsGetImageFromCurrentImageContext()
-        
-        UIGraphicsEndImageContext()
-        
-        return rotateImage
-    }
-    
-    static func drawRotateCWImage() -> UIImage? {
-        guard let rotateCCWImage = self.rotateCCWImage(), let cgImage = rotateCCWImage.cgImage else { return nil }
-        
-        UIGraphicsBeginImageContextWithOptions(rotateCCWImage.size, false, rotateCCWImage.scale )
-        let context = UIGraphicsGetCurrentContext()
-        context?.translateBy(x: rotateCCWImage.size.width, y: rotateCCWImage.size.height)
-        context?.rotate(by: .pi)
-        context?.draw(cgImage, in: CGRect(x: 0, y: 0, width: rotateCCWImage.size.width, height: rotateCCWImage.size.height))
-        let rotateCWImage: UIImage? = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return rotateCWImage
-    }
-    
-    static func drawFlipHorizontally() -> UIImage? {
-        var flippedImage: UIImage?
-        
-        let wholeWidth = 24
-        let wholeHeight = 24
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: wholeWidth, height: wholeHeight), false, 0.0)
-        
-        let arrowWidth = 5
-        let arrowHeight = 6
-        let topbarWidth = wholeWidth - arrowWidth
-        let topbarY = arrowHeight / 2 - 1
-        
-        // topbar
-        let rectangle2Path = UIBezierPath(rect: CGRect(x: 0, y: topbarY, width: topbarWidth, height: 1))
-        UIColor.white.setFill()
-        rectangle2Path.fill()
-        
-        // left arrow
-        let leftarrowPath = UIBezierPath()
-        leftarrowPath.move(to: CGPoint(x: 0, y: topbarY))
-        leftarrowPath.addLine(to: CGPoint(x: arrowWidth, y: 0))
-        leftarrowPath.addLine(to: CGPoint(x: arrowWidth, y: arrowHeight))
-        leftarrowPath.addLine(to: CGPoint(x: 0, y: topbarY))
-        leftarrowPath.close()
-        UIColor.white.setFill()
-        leftarrowPath.fill()
-        
-        // right arrow
-        let rightarrowPath = UIBezierPath()
-        rightarrowPath.move(to: CGPoint(x: wholeWidth, y: topbarY))
-        rightarrowPath.addLine(to: CGPoint(x: wholeWidth - arrowWidth, y: 0))
-        rightarrowPath.addLine(to: CGPoint(x: wholeWidth - arrowWidth, y: arrowHeight))
-        rightarrowPath.addLine(to: CGPoint(x: wholeWidth, y: topbarY))
-        rightarrowPath.close()
-        UIColor.white.setFill()
-        rightarrowPath.fill()
-        
-        let mirrorWidth = wholeWidth / 2 - 1
-        let mirrorHeight = wholeHeight - 8
-        
-        // left mirror
-        let leftMirror = UIBezierPath()
-        leftMirror.move(to: CGPoint(x: 0, y: wholeHeight))
-        leftMirror.addLine(to: CGPoint(x: mirrorWidth, y: wholeHeight))
-        leftMirror.addLine(to: CGPoint(x: mirrorWidth, y: wholeHeight - mirrorHeight))
-        leftMirror.addLine(to: CGPoint(x: 0, y: wholeHeight))
-        leftMirror.close()
-        UIColor.white.setFill()
-        leftMirror.fill()
-        
-        // right mirror
-        let rightMirror = UIBezierPath()
-        rightMirror.move(to: CGPoint(x: wholeWidth, y: wholeHeight))
-        rightMirror.addLine(to: CGPoint(x: wholeWidth - mirrorWidth, y: wholeHeight))
-        rightMirror.addLine(to: CGPoint(x: wholeWidth - mirrorWidth, y: wholeHeight - mirrorHeight))
-        rightMirror.addLine(to: CGPoint(x: wholeWidth, y: wholeHeight))
-        rightMirror.close()
-        UIColor.white.setFill()
-        rightMirror.fill()
-        
-        flippedImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return flippedImage
-        
-    }
-    
     static func drawFlipVertically() -> UIImage? {
         guard let flippedHorizontallyImage = self.flipHorizontally(), let cgImage = flippedHorizontallyImage.cgImage else { return nil }
-        
+
         UIGraphicsBeginImageContextWithOptions(flippedHorizontallyImage.size, false, flippedHorizontallyImage.scale )
         let context = UIGraphicsGetCurrentContext()
         context?.rotate(by: -.pi / 2)
@@ -156,100 +44,27 @@ extension ToolBarButtonImageBuilder {
         UIGraphicsEndImageContext()
         return flippedVerticallyImage
     }
-    
-    static func drawClampImage() -> UIImage? {
-        var clampImage: UIImage?
-        
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: 22, height: 16), false, 0.0)
-        
-        //// Color Declarations
-        let outerBox = UIColor(red: 1, green: 1, blue: 1, alpha: 0.553)
-        let innerBox = UIColor(red: 1, green: 1, blue: 1, alpha: 0.773)
-        
-        //// Rectangle Drawing
-        let rectanglePath = UIBezierPath(rect: CGRect(x: 0, y: 3, width: 13, height: 13))
-        UIColor.white.setFill()
-        rectanglePath.fill()
-        
-        //// Outer
-        //// Top Drawing
-        let topPath = UIBezierPath(rect: CGRect(x: 0, y: 0, width: 22, height: 2))
-        outerBox.setFill()
-        topPath.fill()
-        
-        //// Side Drawing
-        let sidePath = UIBezierPath(rect: CGRect(x: 19, y: 2, width: 3, height: 14))
-        outerBox.setFill()
-        sidePath.fill()
-        
-        //// Rectangle 2 Drawing
-        let rectangle2Path = UIBezierPath(rect: CGRect(x: 14, y: 3, width: 4, height: 13))
-        innerBox.setFill()
-        rectangle2Path.fill()
-        
-        clampImage = UIGraphicsGetImageFromCurrentImageContext()
-        
-        UIGraphicsEndImageContext()
-        return clampImage
-    }
-    
-    static func drawResetImage() -> UIImage? {
-        var resetImage: UIImage?
-        
-        UIGraphicsBeginImageContextWithOptions(CGSize(width: 22, height: 18), false, 0.0)            //// Bezier 2 Drawing
-        let bezier2Path = UIBezierPath()
-        bezier2Path.move(to: CGPoint(x: 22, y: 9))
-        bezier2Path.addCurve(to: CGPoint(x: 13, y: 18), controlPoint1: CGPoint(x: 22, y: 13.97), controlPoint2: CGPoint(x: 17.97, y: 18))
-        bezier2Path.addCurve(to: CGPoint(x: 13, y: 16), controlPoint1: CGPoint(x: 13, y: 17.35), controlPoint2: CGPoint(x: 13, y: 16.68))
-        bezier2Path.addCurve(to: CGPoint(x: 20, y: 9), controlPoint1: CGPoint(x: 16.87, y: 16), controlPoint2: CGPoint(x: 20, y: 12.87))
-        bezier2Path.addCurve(to: CGPoint(x: 13, y: 2), controlPoint1: CGPoint(x: 20, y: 5.13), controlPoint2: CGPoint(x: 16.87, y: 2))
-        bezier2Path.addCurve(to: CGPoint(x: 6.55, y: 6.27), controlPoint1: CGPoint(x: 10.1, y: 2), controlPoint2: CGPoint(x: 7.62, y: 3.76))
-        bezier2Path.addCurve(to: CGPoint(x: 6, y: 9), controlPoint1: CGPoint(x: 6.2, y: 7.11), controlPoint2: CGPoint(x: 6, y: 8.03))
-        bezier2Path.addLine(to: CGPoint(x: 4, y: 9))
-        bezier2Path.addCurve(to: CGPoint(x: 4.65, y: 5.63), controlPoint1: CGPoint(x: 4, y: 7.81), controlPoint2: CGPoint(x: 4.23, y: 6.67))
-        bezier2Path.addCurve(to: CGPoint(x: 7.65, y: 1.76), controlPoint1: CGPoint(x: 5.28, y: 4.08), controlPoint2: CGPoint(x: 6.32, y: 2.74))
-        bezier2Path.addCurve(to: CGPoint(x: 13, y: 0), controlPoint1: CGPoint(x: 9.15, y: 0.65), controlPoint2: CGPoint(x: 11, y: 0))
-        bezier2Path.addCurve(to: CGPoint(x: 22, y: 9), controlPoint1: CGPoint(x: 17.97, y: 0), controlPoint2: CGPoint(x: 22, y: 4.03))
-        bezier2Path.close()
-        UIColor.white.setFill()
-        bezier2Path.fill()
-        
-        //// Polygon Drawing
-        let polygonPath = UIBezierPath()
-        polygonPath.move(to: CGPoint(x: 5, y: 15))
-        polygonPath.addLine(to: CGPoint(x: 10, y: 9))
-        polygonPath.addLine(to: CGPoint(x: 0, y: 9))
-        polygonPath.addLine(to: CGPoint(x: 5, y: 15))
-        polygonPath.close()
-        UIColor.white.setFill()
-        polygonPath.fill()
-        
-        resetImage = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        
-        return resetImage
-    }
-    
+
     static func drawAlterCropper90DegreeImage() -> UIImage? {
         var rotateCropperImage: UIImage?
-        
+
         UIGraphicsBeginImageContextWithOptions(CGSize(width: 22, height: 22), false, 0.0)
-        
+
         //// Draw rectangle
         let rectanglePath1 = UIBezierPath(rect: CGRect(x: 1, y: 5, width: 20, height: 11))
         UIColor.white.setStroke()
         rectanglePath1.lineWidth = 1
         rectanglePath1.stroke()
-        
+
         let rectanglePath2 = UIBezierPath(rect: CGRect(x: 6, y: 1, width: 10, height: 20))
         UIColor.white.setStroke()
         rectanglePath2.lineWidth = 1
         rectanglePath2.stroke()
-        
+
         rotateCropperImage = UIGraphicsGetImageFromCurrentImageContext()
-        
+
         UIGraphicsEndImageContext()
-        
+
         return rotateCropperImage
     }
 }

--- a/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
+++ b/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
@@ -28,23 +28,10 @@
 
 import UIKit
 
-// Hand-drawn fallbacks for toolbar icons that have no SF Symbol equivalent.
-// The rest of the icons use `UIImage(systemName:)` directly (see
-// ToolBarButtonImageBuilder), which is always available on the iOS 15 minimum.
+// Hand-drawn toolbar icon that has no SF Symbol equivalent. The rest of the
+// icons use `UIImage(systemName:)` directly (see ToolBarButtonImageBuilder),
+// which is always available on the iOS 15 minimum.
 extension ToolBarButtonImageBuilder {
-    static func drawFlipVertically() -> UIImage? {
-        guard let flippedHorizontallyImage = self.flipHorizontally(), let cgImage = flippedHorizontallyImage.cgImage else { return nil }
-
-        UIGraphicsBeginImageContextWithOptions(flippedHorizontallyImage.size, false, flippedHorizontallyImage.scale )
-        let context = UIGraphicsGetCurrentContext()
-        context?.rotate(by: -.pi / 2)
-        context?.translateBy(x: -flippedHorizontallyImage.size.height, y: 0)
-        context?.draw(cgImage, in: CGRect(x: 0, y: 0, width: flippedHorizontallyImage.size.height, height: flippedHorizontallyImage.size.width))
-        let flippedVerticallyImage: UIImage? = UIGraphicsGetImageFromCurrentImageContext()
-        UIGraphicsEndImageContext()
-        return flippedVerticallyImage
-    }
-
     static func drawAlterCropper90DegreeImage() -> UIImage? {
         var rotateCropperImage: UIImage?
 

--- a/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
+++ b/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder+DrawImage.swift
@@ -30,7 +30,7 @@ import UIKit
 
 // Hand-drawn toolbar icon that has no SF Symbol equivalent. The rest of the
 // icons use `UIImage(systemName:)` directly (see ToolBarButtonImageBuilder),
-// which is always available on the iOS 15 minimum.
+// which is always available on the iOS/macCatalyst 15 minimum.
 extension ToolBarButtonImageBuilder {
     static func drawAlterCropper90DegreeImage() -> UIImage? {
         var rotateCropperImage: UIImage?

--- a/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder.swift
+++ b/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder.swift
@@ -37,14 +37,6 @@ struct ToolBarButtonImageBuilder {
         UIImage(systemName: "rotate.right")
     }
 
-    static func flipHorizontally() -> UIImage? {
-        UIImage(systemName: "flip.horizontal")
-    }
-
-    static func flipVertically() -> UIImage? {
-        drawFlipVertically()
-    }
-
     static func clampImage() -> UIImage? {
         UIImage(systemName: "aspectratio")
     }

--- a/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder.swift
+++ b/Sources/Mantis/CropViewController/ToolBarButtonImageBuilder.swift
@@ -30,88 +30,56 @@ import UIKit
 
 struct ToolBarButtonImageBuilder {
     static func rotateCCWImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "rotate.left")
-        }
-        
-        return drawRotateCCWImage()
+        UIImage(systemName: "rotate.left")
     }
-    
+
     static func rotateCWImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "rotate.right")
-        }
-        
-        return drawRotateCWImage()
+        UIImage(systemName: "rotate.right")
     }
-    
+
     static func flipHorizontally() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "flip.horizontal")
-        }
-        
-        return drawFlipHorizontally()
+        UIImage(systemName: "flip.horizontal")
     }
-    
+
     static func flipVertically() -> UIImage? {
         drawFlipVertically()
     }
-    
+
     static func clampImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "aspectratio")
-        }
-        
-        return drawClampImage()
+        UIImage(systemName: "aspectratio")
     }
-    
+
     static func resetImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "arrow.2.circlepath")
-        }
-        
-        return drawResetImage()
+        UIImage(systemName: "arrow.2.circlepath")
     }
-    
+
     static func alterCropper90DegreeImage() -> UIImage? {
         drawAlterCropper90DegreeImage()
     }
-    
+
     static func horizontallyFlipImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "flip.horizontal")
-        }
-        
-        return nil
+        UIImage(systemName: "flip.horizontal")
     }
-    
+
     static func verticallyFlipImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            guard let horizontallyFlippedImage = horizontallyFlipImage(),
-                  let cgImage = horizontallyFlippedImage.cgImage else {
-                return nil
-            }
-            
-            let rotatedImage = UIImage(cgImage: cgImage, scale: horizontallyFlippedImage.scale, orientation: .leftMirrored)
-            
-            let newSize = CGSize(width: horizontallyFlippedImage.size.height, height: horizontallyFlippedImage.size.width)
-            UIGraphicsBeginImageContextWithOptions(newSize, false, horizontallyFlippedImage.scale)
-            rotatedImage.draw(in: CGRect(origin: .zero, size: newSize))
-            
-            let newImage = UIGraphicsGetImageFromCurrentImageContext()
-            UIGraphicsEndImageContext()
-            
-            return newImage
+        guard let horizontallyFlippedImage = horizontallyFlipImage(),
+              let cgImage = horizontallyFlippedImage.cgImage else {
+            return nil
         }
-        
-        return nil
+
+        let rotatedImage = UIImage(cgImage: cgImage, scale: horizontallyFlippedImage.scale, orientation: .leftMirrored)
+
+        let newSize = CGSize(width: horizontallyFlippedImage.size.height, height: horizontallyFlippedImage.size.width)
+        UIGraphicsBeginImageContextWithOptions(newSize, false, horizontallyFlippedImage.scale)
+        rotatedImage.draw(in: CGRect(origin: .zero, size: newSize))
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return newImage
     }
-    
+
     static func autoAdjustImage() -> UIImage? {
-        if #available(macCatalyst 13.1, iOS 13.0, *) {
-            return UIImage(systemName: "camera.metering.none")
-        }
-        
-        return nil
+        UIImage(systemName: "camera.metering.none")
     }
 }

--- a/Tests/MantisTests/ToolBarButtonImageBuilderTests.swift
+++ b/Tests/MantisTests/ToolBarButtonImageBuilderTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Mantis
+
+/// Guards the toolbar icon builder after the iOS-15 cleanup removed the
+/// pre-iOS-13 hand-drawn fallbacks. Every button icon must still resolve —
+/// the SF Symbol names must be valid, and the two remaining hand-drawn icons
+/// (vertical flip, alter-cropper-90°) must still render.
+final class ToolBarButtonImageBuilderTests: XCTestCase {
+    func testAllButtonIconsResolve() {
+        XCTAssertNotNil(ToolBarButtonImageBuilder.rotateCCWImage(), "rotate.left")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.rotateCWImage(), "rotate.right")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.flipHorizontally(), "flip.horizontal")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.clampImage(), "aspectratio")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.resetImage(), "arrow.2.circlepath")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.horizontallyFlipImage(), "flip.horizontal")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.autoAdjustImage(), "camera.metering.none")
+
+        // Hand-drawn icons with no SF Symbol equivalent (kept after cleanup).
+        XCTAssertNotNil(ToolBarButtonImageBuilder.flipVertically(), "drawFlipVertically")
+        XCTAssertNotNil(ToolBarButtonImageBuilder.alterCropper90DegreeImage(), "drawAlterCropper90DegreeImage")
+
+        // Derived from horizontallyFlipImage() at runtime.
+        XCTAssertNotNil(ToolBarButtonImageBuilder.verticallyFlipImage(), "verticallyFlipImage")
+    }
+}

--- a/Tests/MantisTests/ToolBarButtonImageBuilderTests.swift
+++ b/Tests/MantisTests/ToolBarButtonImageBuilderTests.swift
@@ -3,20 +3,18 @@ import XCTest
 
 /// Guards the toolbar icon builder after the iOS-15 cleanup removed the
 /// pre-iOS-13 hand-drawn fallbacks. Every button icon must still resolve —
-/// the SF Symbol names must be valid, and the two remaining hand-drawn icons
-/// (vertical flip, alter-cropper-90°) must still render.
+/// the SF Symbol names must be valid, and the one remaining hand-drawn icon
+/// (alter-cropper-90°) must still render.
 final class ToolBarButtonImageBuilderTests: XCTestCase {
     func testAllButtonIconsResolve() {
         XCTAssertNotNil(ToolBarButtonImageBuilder.rotateCCWImage(), "rotate.left")
         XCTAssertNotNil(ToolBarButtonImageBuilder.rotateCWImage(), "rotate.right")
-        XCTAssertNotNil(ToolBarButtonImageBuilder.flipHorizontally(), "flip.horizontal")
         XCTAssertNotNil(ToolBarButtonImageBuilder.clampImage(), "aspectratio")
         XCTAssertNotNil(ToolBarButtonImageBuilder.resetImage(), "arrow.2.circlepath")
         XCTAssertNotNil(ToolBarButtonImageBuilder.horizontallyFlipImage(), "flip.horizontal")
         XCTAssertNotNil(ToolBarButtonImageBuilder.autoAdjustImage(), "camera.metering.none")
 
-        // Hand-drawn icons with no SF Symbol equivalent (kept after cleanup).
-        XCTAssertNotNil(ToolBarButtonImageBuilder.flipVertically(), "drawFlipVertically")
+        // Hand-drawn icon with no SF Symbol equivalent (kept after cleanup).
         XCTAssertNotNil(ToolBarButtonImageBuilder.alterCropper90DegreeImage(), "drawAlterCropper90DegreeImage")
 
         // Derived from horizontallyFlipImage() at runtime.


### PR DESCRIPTION
Follow-up to the iOS 15 minimum (#528). This is the ToolBar dead-code cleanup that was deliberately deferred from that PR because it cascades into deleting parts of a shared file.

## Context

`ToolBarButtonImageBuilder` wrapped each SF Symbol icon in `if #available(macCatalyst 13.1, iOS 13.0, *)` with a hand-drawn Core Graphics fallback for pre-SF-Symbol systems:

```swift
static func rotateCCWImage() -> UIImage? {
    if #available(macCatalyst 13.1, iOS 13.0, *) {
        return UIImage(systemName: "rotate.left")   // always taken on iOS 15
    }
    return drawRotateCCWImage()                       // dead
}
```

With the iOS 15 floor those guards are always true, so the fallbacks are unreachable.

## What

- **Unwrap the 8 `#available` guards** in `ToolBarButtonImageBuilder.swift`; each SF-Symbol method becomes a one-liner.
- **Delete the 6 now-dead `draw*` fallbacks** from `ToolBarButtonImageBuilder+DrawImage.swift`: `drawRotateCCWImage`, `drawRotateCWImage`, `drawFlipHorizontally`, `drawClampImage`, `drawResetImage`, and `drawFlipVertically`.
- **Remove the dead `flipHorizontally()` / `flipVertically()` methods.** Verified via the call graph: the toolbar buttons use `horizontallyFlipImage()` and `verticallyFlipImage()`; `flipHorizontally()` was only reached by `drawFlipVertically()`, which was only reached by the never-called `flipVertically()` — the whole trio was unreachable in production.
- **Keep `drawAlterCropper90DegreeImage`** — the only icon with no SF Symbol equivalent, still called unconditionally by `alterCropper90DegreeImage()`.

The live vertical-flip path is unchanged: `verticallyFlipImage()` still derives from `horizontallyFlipImage()` (the `flip.horizontal` SF Symbol) via `.leftMirrored` at runtime.

Net **~240 lines** of unreachable code removed. Runtime behavior is unchanged — the removed branches/methods could never execute at the iOS 15 minimum.

## Tests

Added `ToolBarButtonImageBuilderTests` asserting **every** toolbar icon still resolves — the SF Symbol names are valid, the derived `verticallyFlipImage()` renders, and the one remaining hand-drawn icon (`alterCropper90DegreeImage`) renders.

Verified in **Xcode 27**: full suite **275 tests** pass.

## Not a breaking change

Pure dead-code removal; `refactor:` — no version-bump implications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated toolbar button icons to consistently use SF Symbols, removing legacy OS-compatibility fallbacks and leaving only the one hand-drawn icon without an SF Symbol equivalent.
* **Bug Fixes**
  * Improved robustness of derived toolbar icons, including vertical flip rendering.
* **Tests**
  * Added `ToolBarButtonImageBuilderTests` to verify all toolbar icon factories return non-`nil` images and that the remaining hand-drawn fallback is still available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
